### PR TITLE
feat(almacenamiento): pantalla para ver y borrar los puzzles descargados

### DIFF
--- a/apps/chessColate/src/app/app.routes.ts
+++ b/apps/chessColate/src/app/app.routes.ts
@@ -111,6 +111,11 @@ export const routes: Routes = [
       import('./pages/settings/settings.page').then((m) => m.SettingsPage),
   },
   {
+    path: 'settings/storage',
+    loadComponent: () =>
+      import('./pages/settings/storage/storage.page').then((m) => m.StoragePage),
+  },
+  {
     path: 'reminders',
     loadComponent: () =>
       import('./pages/reminders/reminders.page').then((m) => m.RemindersPage),

--- a/apps/chessColate/src/app/pages/settings/settings.page.html
+++ b/apps/chessColate/src/app/pages/settings/settings.page.html
@@ -64,6 +64,32 @@
         </section>
       }
 
+      <!-- Almacenamiento (también en web: el caché de puzzles vive en IndexedDB) -->
+      <section class="mb-8">
+        <div class="flex items-center gap-2 mb-3 opacity-80">
+          <ion-icon name="server-outline" class="text-xl"></ion-icon>
+          <h2 class="text-lg font-bold">{{ 'SETTINGS.storage' | transloco }}</h2>
+        </div>
+
+        <ul class="menu bg-base-200/40 border border-base-content/10 w-full rounded-box gap-1 p-2">
+          <li>
+            <a (click)="goToStorage()" class="flex items-center justify-between py-3">
+              <div>
+                <div class="text-base">{{ 'STORAGE.settingsRowTitle' | transloco }}</div>
+                <div class="text-xs opacity-60">
+                  @if (storageSummary) {
+                    {{ 'STORAGE.summary' | transloco: storageSummary }}
+                  } @else {
+                    {{ 'STORAGE.loading' | transloco }}
+                  }
+                </div>
+              </div>
+              <ion-icon name="chevron-forward-outline" class="text-xl opacity-60"></ion-icon>
+            </a>
+          </li>
+        </ul>
+      </section>
+
       <!-- Apariencia (próximamente: estilo de piezas y color de tablero) -->
       <!--
         Estos ajustes se implementarán más adelante. El modelo Profile ya tiene

--- a/apps/chessColate/src/app/pages/settings/settings.page.ts
+++ b/apps/chessColate/src/app/pages/settings/settings.page.ts
@@ -14,6 +14,7 @@ import {
   homeOutline,
   notificationsOutline,
   chevronForwardOutline,
+  serverOutline,
 } from 'ionicons/icons';
 import { Subscription } from 'rxjs';
 
@@ -21,6 +22,7 @@ import { NavbarComponent } from '@shared/components/navbar/navbar.component';
 import { ProfileService } from '@services/profile.service';
 import { LanguageService, SupportedLang } from '@services/language.service';
 import { AnalyticsService } from '@services/analytics.service';
+import { PuzzleStorageService } from '@services/puzzle-storage.service';
 
 addIcons({
   languageOutline,
@@ -31,6 +33,7 @@ addIcons({
   homeOutline,
   notificationsOutline,
   chevronForwardOutline,
+  serverOutline,
 });
 
 interface LanguageOption {
@@ -50,11 +53,17 @@ export class SettingsPage implements OnInit, OnDestroy {
   private profileService = inject(ProfileService);
   private router = inject(Router);
   private analyticsService = inject(AnalyticsService);
+  private puzzleStorageService = inject(PuzzleStorageService);
 
   readonly isNativePlatform = Capacitor.isNativePlatform();
 
   currentLang: SupportedLang = this.languageService.getCurrentLang();
   isAuthenticated = false;
+  /**
+   * Resumen de lo descargado ("124 archivos · 18,3 MB"), ya formateado para
+   * interpolarlo en la traducción. `null` mientras se calcula.
+   */
+  storageSummary: { files: number; size: string } | null = null;
 
   // Mapea cada idioma disponible con su clave de traducción en COMMON.languages
   readonly languages: LanguageOption[] = [
@@ -70,6 +79,25 @@ export class SettingsPage implements OnInit, OnDestroy {
       // Mantener sincronizado el idioma activo con el del perfil cargado
       this.currentLang = this.languageService.getCurrentLang();
     });
+
+    void this.loadStorageSummary();
+  }
+
+  /**
+   * Calcula el resumen de almacenamiento sin bloquear la pantalla: si falla
+   * (p. ej. sin IndexedDB) la fila se queda con el texto de carga en vez de
+   * romper Ajustes.
+   */
+  private async loadStorageSummary(): Promise<void> {
+    try {
+      const summary = await this.puzzleStorageService.getSummary();
+      this.storageSummary = {
+        files: summary.files,
+        size: this.puzzleStorageService.formatBytes(summary.sizeBytes),
+      };
+    } catch (error) {
+      console.warn('[SettingsPage] No se pudo calcular el almacenamiento:', error);
+    }
   }
 
   ngOnDestroy(): void {
@@ -82,6 +110,10 @@ export class SettingsPage implements OnInit, OnDestroy {
 
   goToReminders(): void {
     this.router.navigate(['/reminders']);
+  }
+
+  goToStorage(): void {
+    this.router.navigate(['/settings/storage']);
   }
 
   /**

--- a/apps/chessColate/src/app/pages/settings/storage/storage.page.html
+++ b/apps/chessColate/src/app/pages/settings/storage/storage.page.html
@@ -1,0 +1,113 @@
+<ion-content [fullscreen]="true">
+  <div class="min-h-screen bg-base-100" data-theme="halloween">
+    <app-navbar></app-navbar>
+
+    <div class="container mx-auto px-4 py-8 max-w-lg pb-16">
+
+      <!-- Header -->
+      <div class="mb-6">
+        <div class="breadcrumbs text-sm mb-1">
+          <ul>
+            <li>
+              <a (click)="goToHome()" class="cursor-pointer gap-1">
+                <ion-icon name="home-outline" class="h-4 w-4"></ion-icon>
+                <span>{{ 'MENU.navigation.home' | transloco }}</span>
+              </a>
+            </li>
+            <li>
+              <a (click)="goToSettings()" class="cursor-pointer gap-1">
+                <ion-icon name="settings-outline" class="h-4 w-4"></ion-icon>
+                <span>{{ 'SETTINGS.title' | transloco }}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <h2 class="text-2xl font-bold">{{ 'STORAGE.pageTitle' | transloco }}</h2>
+      </div>
+
+      @if (loading) {
+        <!-- Skeleton: el primer listado calcula el tamaño de descargas antiguas -->
+        <div class="flex flex-col gap-2">
+          <div class="skeleton h-14 w-full"></div>
+          <div class="skeleton h-14 w-full"></div>
+          <div class="skeleton h-14 w-full"></div>
+        </div>
+      } @else if (totalFiles === 0) {
+        <div class="bg-base-200/40 border border-base-content/10 rounded-box p-6 text-center">
+          <ion-icon name="server-outline" class="text-4xl opacity-40"></ion-icon>
+          <p class="mt-3 text-sm opacity-70">{{ 'STORAGE.empty' | transloco }}</p>
+        </div>
+      } @else {
+
+        <!-- Resumen + borrar todo -->
+        <div class="bg-base-200/40 border border-base-content/10 rounded-box p-4 mb-4
+                    flex items-center justify-between gap-4">
+          <div>
+            <div class="text-base font-bold">
+              {{ 'STORAGE.summary' | transloco: { files: totalFiles, size: formatBytes(totalSizeBytes) } }}
+            </div>
+            <div class="text-xs opacity-60 mt-1">{{ 'STORAGE.intro' | transloco }}</div>
+          </div>
+          <button class="btn btn-sm btn-outline btn-error shrink-0" (click)="confirmDeleteAll()">
+            {{ 'STORAGE.deleteAll' | transloco }}
+          </button>
+        </div>
+
+        <!-- Lista agrupada por tema / apertura -->
+        <ul class="flex flex-col gap-2">
+          @for (group of groups; track group.key) {
+            <li class="bg-base-200/40 border border-base-content/10 rounded-box overflow-hidden">
+
+              <!-- Cabecera del grupo -->
+              <div class="flex items-center gap-2 p-3">
+                <button class="flex items-center gap-2 flex-1 text-left min-w-0"
+                  (click)="toggleGroup(group)">
+                  <ion-icon name="chevron-down-outline"
+                    class="text-base opacity-60 transition-transform shrink-0"
+                    [class.-rotate-90]="!isExpanded(group)"></ion-icon>
+                  <div class="min-w-0">
+                    <div class="text-base truncate">{{ group.name }}</div>
+                    <div class="text-xs opacity-60">
+                      {{ filesCountLabel(group.files.length) }} · {{ groupSizeLabel(group) }}
+                      @if (group.kind === 'opening') {
+                        <span class="badge badge-ghost badge-xs ml-1">{{ 'STORAGE.openings' | transloco }}</span>
+                      }
+                    </div>
+                  </div>
+                </button>
+                <button class="btn btn-ghost btn-sm btn-square text-error shrink-0"
+                  [attr.aria-label]="'STORAGE.deleteAll' | transloco"
+                  (click)="confirmDeleteGroup(group)">
+                  <ion-icon name="trash-outline" class="text-lg"></ion-icon>
+                </button>
+              </div>
+
+              <!-- Archivos del grupo -->
+              @if (isExpanded(group)) {
+                <ul class="border-t border-base-content/10">
+                  @for (file of group.files; track file.url) {
+                    <li class="flex items-center gap-2 py-2 pl-9 pr-3 border-b border-base-content/5 last:border-b-0">
+                      <div class="flex-1 min-w-0 text-sm">
+                        <span>{{ file.eloLabel }}</span>
+                        @if (file.count !== undefined) {
+                          <span class="opacity-60"> · {{ 'STORAGE.puzzlesCount' | transloco: { count: file.count } }}</span>
+                        }
+                        <span class="opacity-60"> · {{ fileSizeLabel(file) }}</span>
+                      </div>
+                      <button class="btn btn-ghost btn-xs btn-square text-error shrink-0"
+                        [attr.aria-label]="'STORAGE.confirm.delete' | transloco"
+                        (click)="confirmDeleteFile(group, file)">
+                        <ion-icon name="trash-outline" class="text-base"></ion-icon>
+                      </button>
+                    </li>
+                  }
+                </ul>
+              }
+            </li>
+          }
+        </ul>
+      }
+
+    </div>
+  </div>
+</ion-content>

--- a/apps/chessColate/src/app/pages/settings/storage/storage.page.scss
+++ b/apps/chessColate/src/app/pages/settings/storage/storage.page.scss
@@ -1,0 +1,1 @@
+// Estilos vía DaisyUI/Tailwind en la plantilla.

--- a/apps/chessColate/src/app/pages/settings/storage/storage.page.ts
+++ b/apps/chessColate/src/app/pages/settings/storage/storage.page.ts
@@ -1,0 +1,216 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { AlertController, IonContent, IonIcon } from '@ionic/angular/standalone';
+import { TranslocoPipe, TranslocoService } from '@jsverse/transloco';
+import { addIcons } from 'ionicons';
+import {
+  homeOutline,
+  settingsOutline,
+  serverOutline,
+  trashOutline,
+  chevronDownOutline,
+} from 'ionicons/icons';
+
+import { NavbarComponent } from '@shared/components/navbar/navbar.component';
+import { AnalyticsService } from '@services/analytics.service';
+import {
+  PuzzleStorageService,
+  StorageFileItem,
+  StorageGroup,
+} from '@services/puzzle-storage.service';
+
+addIcons({
+  homeOutline,
+  settingsOutline,
+  serverOutline,
+  trashOutline,
+  chevronDownOutline,
+});
+
+/**
+ * Pantalla de gestión de descargas: lista los archivos de puzzles guardados en
+ * el dispositivo, agrupados por tema o apertura, y permite borrarlos uno a uno,
+ * por grupo o todos de golpe.
+ *
+ * Todo lo que se lista es caché: borrar nunca pierde progreso, ELO ni planes,
+ * solo obliga a volver a descargar el archivo la próxima vez que haga falta.
+ */
+@Component({
+  selector: 'app-storage',
+  standalone: true,
+  imports: [CommonModule, TranslocoPipe, IonContent, IonIcon, NavbarComponent],
+  templateUrl: './storage.page.html',
+  styleUrls: ['./storage.page.scss'],
+})
+export class StoragePage implements OnInit {
+  private router = inject(Router);
+  private alertController = inject(AlertController);
+  private translocoService = inject(TranslocoService);
+  private analyticsService = inject(AnalyticsService);
+  private puzzleStorageService = inject(PuzzleStorageService);
+
+  groups: StorageGroup[] = [];
+  totalFiles = 0;
+  totalSizeBytes = 0;
+  /** El primer listado puede tardar (completa el tamaño de descargas antiguas). */
+  loading = true;
+  /** Claves de los grupos desplegados. */
+  private expanded = new Set<string>();
+
+  async ngOnInit(): Promise<void> {
+    await this.refresh();
+
+    // Primera medida real de cuánto caché acumula un usuario
+    void this.analyticsService.logEvent('puzzle_storage_opened', {
+      files_count: this.totalFiles,
+      size_mb: this.toMb(this.totalSizeBytes),
+    });
+  }
+
+  goToHome(): void {
+    this.router.navigate(['/home']);
+  }
+
+  goToSettings(): void {
+    this.router.navigate(['/settings']);
+  }
+
+  isExpanded(group: StorageGroup): boolean {
+    return this.expanded.has(group.key);
+  }
+
+  toggleGroup(group: StorageGroup): void {
+    if (this.expanded.has(group.key)) {
+      this.expanded.delete(group.key);
+    } else {
+      this.expanded.add(group.key);
+    }
+  }
+
+  formatBytes(bytes: number): string {
+    return this.puzzleStorageService.formatBytes(bytes);
+  }
+
+  /** Tamaño de una fila, o "—" cuando no se pudo calcular. */
+  fileSizeLabel(file: StorageFileItem): string {
+    return file.sizeUnknown ? '—' : this.formatBytes(file.sizeBytes);
+  }
+
+  groupSizeLabel(group: StorageGroup): string {
+    return group.sizeUnknown && group.sizeBytes === 0 ? '—' : this.formatBytes(group.sizeBytes);
+  }
+
+  filesCountLabel(count: number): string {
+    return count === 1
+      ? this.translocoService.translate('STORAGE.oneFile')
+      : this.translocoService.translate('STORAGE.filesCount', { count });
+  }
+
+  async confirmDeleteFile(group: StorageGroup, file: StorageFileItem): Promise<void> {
+    const confirmed = await this.confirm(
+      this.translocoService.translate('STORAGE.confirm.fileTitle'),
+      this.translocoService.translate('STORAGE.confirm.fileMessage', {
+        name: group.name,
+        eloRange: file.eloLabel,
+      })
+    );
+    if (!confirmed) return;
+
+    await this.puzzleStorageService.deleteFile(file.url);
+    void this.analyticsService.logEvent('puzzle_storage_file_deleted', {
+      theme: group.key,
+      elo_start: file.eloStart ?? 0,
+    });
+    await this.refresh();
+  }
+
+  async confirmDeleteGroup(group: StorageGroup): Promise<void> {
+    const confirmed = await this.confirm(
+      this.translocoService.translate('STORAGE.confirm.groupTitle', { name: group.name }),
+      this.translocoService.translate('STORAGE.confirm.groupMessage', {
+        files: group.files.length,
+        size: this.groupSizeLabel(group),
+      })
+    );
+    if (!confirmed) return;
+
+    const filesCount = group.files.length;
+    const sizeMb = this.toMb(group.sizeBytes);
+    await this.puzzleStorageService.deleteGroup(group);
+    void this.analyticsService.logEvent('puzzle_storage_theme_deleted', {
+      theme: group.key,
+      files_count: filesCount,
+      size_mb: sizeMb,
+    });
+    await this.refresh();
+  }
+
+  async confirmDeleteAll(): Promise<void> {
+    const confirmed = await this.confirm(
+      this.translocoService.translate('STORAGE.confirm.allTitle'),
+      this.translocoService.translate('STORAGE.confirm.allMessage', {
+        files: this.totalFiles,
+        size: this.formatBytes(this.totalSizeBytes),
+      })
+    );
+    if (!confirmed) return;
+
+    const filesCount = this.totalFiles;
+    const sizeMb = this.toMb(this.totalSizeBytes);
+    await this.puzzleStorageService.deleteAll();
+    void this.analyticsService.logEvent('puzzle_storage_cleared', {
+      files_count: filesCount,
+      size_mb: sizeMb,
+    });
+    await this.refresh();
+  }
+
+  /**
+   * Vuelve a leer el almacenamiento y recalcula los totales. La lista
+   * encogiendo es el feedback del borrado: no hace falta un toast.
+   */
+  private async refresh(): Promise<void> {
+    this.loading = true;
+    try {
+      this.groups = await this.puzzleStorageService.getGroups();
+      this.totalFiles = this.groups.reduce((total, group) => total + group.files.length, 0);
+      this.totalSizeBytes = this.groups.reduce((total, group) => total + group.sizeBytes, 0);
+      // Un grupo que ya no existe no debe seguir marcado como desplegado
+      const keys = new Set(this.groups.map((group) => group.key));
+      this.expanded = new Set([...this.expanded].filter((key) => keys.has(key)));
+    } catch (error) {
+      console.warn('[StoragePage] No se pudo leer el almacenamiento:', error);
+      this.groups = [];
+      this.totalFiles = 0;
+      this.totalSizeBytes = 0;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  private async confirm(header: string, message: string): Promise<boolean> {
+    const alert = await this.alertController.create({
+      header,
+      message,
+      buttons: [
+        {
+          text: this.translocoService.translate('COMMON.actions.cancel'),
+          role: 'cancel',
+        },
+        {
+          text: this.translocoService.translate('STORAGE.confirm.delete'),
+          role: 'destructive',
+        },
+      ],
+    });
+    await alert.present();
+    const { role } = await alert.onDidDismiss();
+    return role === 'destructive';
+  }
+
+  /** MB con un decimal, para no enviar bytes crudos a analítica. */
+  private toMb(bytes: number): number {
+    return Math.round((bytes / (1024 * 1024)) * 10) / 10;
+  }
+}

--- a/apps/chessColate/src/app/services/analytics.service.ts
+++ b/apps/chessColate/src/app/services/analytics.service.ts
@@ -34,7 +34,11 @@ export type AnalyticsEventName =
   | 'training_reminder_tapped'
   | 'training_reminder_manual_created'
   | 'training_reminder_manual_deleted'
-  | 'training_reminder_test_sent';
+  | 'training_reminder_test_sent'
+  | 'puzzle_storage_opened'
+  | 'puzzle_storage_file_deleted'
+  | 'puzzle_storage_theme_deleted'
+  | 'puzzle_storage_cleared';
 
 /** Valores primitivos admitidos por GA4 como parámetros de evento. */
 export type AnalyticsParams = Record<string, string | number | boolean>;

--- a/apps/chessColate/src/app/services/puzzle-storage.service.spec.ts
+++ b/apps/chessColate/src/app/services/puzzle-storage.service.spec.ts
@@ -1,0 +1,140 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TranslocoService } from '@jsverse/transloco';
+
+import { CachedFileIndexEntry, PuzzlesProvider } from '@chesspark/puzzles-provider';
+
+import { AppService } from '@services/app.service';
+import { PuzzleStorageService } from '@services/puzzle-storage.service';
+
+/** Doble del servicio de caché: solo lo que consume la fachada. */
+const cacheServiceMock = {
+  listCachedFiles: jest.fn<Promise<CachedFileIndexEntry[]>, []>(),
+  getStorageSummary: jest.fn(),
+  deleteCachedPuzzles: jest.fn().mockResolvedValue(undefined),
+  deleteCachedFiles: jest.fn().mockResolvedValue(undefined),
+  clearCache: jest.fn().mockResolvedValue(undefined),
+  clearInfinityPool: jest.fn().mockResolvedValue(undefined),
+};
+
+const themeUrl = (theme: string, eloStart: number) =>
+  `https://cdn.jsdelivr.net/gh/json-alzate/chesscolate-puzzles-files-themes-a-h@main/puzzlesFilesThemes/${theme}/${theme}_${eloStart}_${eloStart + 19}.json`;
+
+describe('PuzzleStorageService', () => {
+  let service: PuzzleStorageService;
+  let activeLang = 'es';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    activeLang = 'es';
+
+    TestBed.configureTestingModule({
+      providers: [
+        PuzzleStorageService,
+        { provide: PuzzlesProvider, useValue: { getCacheService: () => cacheServiceMock } },
+        {
+          provide: AppService,
+          useValue: {
+            getNameThemePuzzleByValue: (value: string) =>
+              value === 'fork' ? 'Horquilla' : '',
+            getNameOpeningByValue: () => 'Defensa Siciliana',
+          },
+        },
+        {
+          provide: TranslocoService,
+          useValue: {
+            getActiveLang: () => activeLang,
+            translate: (key: string) => key,
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(PuzzleStorageService);
+  });
+
+  it('agrupa por tema, ordena los grupos por tamaño y los archivos por ELO', async () => {
+    cacheServiceMock.listCachedFiles.mockResolvedValue([
+      { key: themeUrl('fork', 1520), timestamp: 1, theme: 'fork', eloStart: 1520, eloEnd: 1539, count: 200, sizeBytes: 1000 },
+      { key: themeUrl('fork', 1500), timestamp: 2, theme: 'fork', eloStart: 1500, eloEnd: 1519, count: 200, sizeBytes: 1000 },
+      { key: themeUrl('pin', 1500), timestamp: 3, theme: 'pin', eloStart: 1500, eloEnd: 1519, count: 100, sizeBytes: 5000 },
+    ]);
+
+    const groups = await service.getGroups();
+
+    expect(groups.map((group) => group.key)).toEqual(['pin', 'fork']);
+    expect(groups[1].files.map((file) => file.eloStart)).toEqual([1500, 1520]);
+    expect(groups[1].sizeBytes).toBe(2000);
+  });
+
+  it('usa el nombre traducido del tema y cae al valor interno si no lo conoce', async () => {
+    cacheServiceMock.listCachedFiles.mockResolvedValue([
+      { key: themeUrl('fork', 1500), timestamp: 1, theme: 'fork', eloStart: 1500, eloEnd: 1519, sizeBytes: 10 },
+      { key: themeUrl('temaRaro', 1500), timestamp: 1, theme: 'temaRaro', eloStart: 1500, eloEnd: 1519, sizeBytes: 5 },
+    ]);
+
+    const groups = await service.getGroups();
+
+    expect(groups.find((group) => group.key === 'fork')?.name).toBe('Horquilla');
+    expect(groups.find((group) => group.key === 'temaRaro')?.name).toBe('temaRaro');
+  });
+
+  it('separa las aperturas en su propio grupo', async () => {
+    cacheServiceMock.listCachedFiles.mockResolvedValue([
+      { key: 'x/puzzlesFilesOpenings/Sicilian_Defense/Sicilian_Defense_1500_1519.json', timestamp: 1, opening: 'Sicilian_Defense', eloStart: 1500, eloEnd: 1519, sizeBytes: 10 },
+    ]);
+
+    const groups = await service.getGroups();
+
+    expect(groups[0].kind).toBe('opening');
+    expect(groups[0].name).toBe('Defensa Siciliana');
+  });
+
+  it('marca como desconocido el tamaño que no se pudo calcular', async () => {
+    cacheServiceMock.listCachedFiles.mockResolvedValue([
+      { key: themeUrl('fork', 1500), timestamp: 1, theme: 'fork', eloStart: 1500, eloEnd: 1519 },
+    ]);
+
+    const groups = await service.getGroups();
+
+    expect(groups[0].files[0].sizeUnknown).toBe(true);
+    expect(groups[0].files[0].sizeBytes).toBe(0);
+    expect(groups[0].sizeUnknown).toBe(true);
+  });
+
+  it('borrar un grupo elimina todos sus archivos de una vez', async () => {
+    cacheServiceMock.listCachedFiles.mockResolvedValue([
+      { key: themeUrl('fork', 1500), timestamp: 1, theme: 'fork', eloStart: 1500, eloEnd: 1519, sizeBytes: 10 },
+      { key: themeUrl('fork', 1520), timestamp: 1, theme: 'fork', eloStart: 1520, eloEnd: 1539, sizeBytes: 10 },
+    ]);
+
+    const [group] = await service.getGroups();
+    await service.deleteGroup(group);
+
+    expect(cacheServiceMock.deleteCachedFiles).toHaveBeenCalledWith([
+      themeUrl('fork', 1500),
+      themeUrl('fork', 1520),
+    ]);
+  });
+
+  it('borrar todo vacía también el pool de infinity', async () => {
+    await service.deleteAll();
+
+    expect(cacheServiceMock.clearCache).toHaveBeenCalled();
+    expect(cacheServiceMock.clearInfinityPool).toHaveBeenCalled();
+  });
+
+  it('formatea el tamaño con el separador decimal del idioma activo', () => {
+    const bytes = Math.round(18.3 * 1024 * 1024);
+
+    expect(service.formatBytes(bytes)).toBe('18,3 MB');
+
+    activeLang = 'en';
+    expect(service.formatBytes(bytes)).toBe('18.3 MB');
+  });
+
+  it('formatea archivos pequeños en KB', () => {
+    expect(service.formatBytes(148 * 1024)).toBe('148 KB');
+    expect(service.formatBytes(0)).toBe('0 KB');
+  });
+});

--- a/apps/chessColate/src/app/services/puzzle-storage.service.ts
+++ b/apps/chessColate/src/app/services/puzzle-storage.service.ts
@@ -1,0 +1,189 @@
+import { Injectable, inject } from '@angular/core';
+
+import { TranslocoService } from '@jsverse/transloco';
+
+import {
+  CachedFileIndexEntry,
+  PuzzlesProvider,
+  StorageSummary,
+} from '@chesspark/puzzles-provider';
+
+import { AppService } from '@services/app.service';
+
+/** Un archivo descargado, tal como se muestra en una fila de la lista. */
+export interface StorageFileItem {
+  /** URL del CDN — clave de borrado. Nunca se muestra al usuario. */
+  url: string;
+  eloStart?: number;
+  eloEnd?: number;
+  /** Rango listo para pintar: "1500–1519", o "—" si no se pudo derivar. */
+  eloLabel: string;
+  count?: number;
+  sizeBytes: number;
+  /** true si el tamaño no se pudo calcular (se pinta "—") */
+  sizeUnknown: boolean;
+  timestamp: number;
+}
+
+/** Grupo de archivos de un mismo tema o de una misma apertura. */
+export interface StorageGroup {
+  /** Valor interno: 'fork', 'Sicilian_Defense'… */
+  key: string;
+  kind: 'theme' | 'opening' | 'unknown';
+  /** Nombre traducido para mostrar. */
+  name: string;
+  files: StorageFileItem[];
+  sizeBytes: number;
+  sizeUnknown: boolean;
+}
+
+/**
+ * Fachada de la pantalla de gestión de descargas.
+ *
+ * Traduce lo que hay en IndexedDB (URLs del CDN) a algo legible: agrupa por
+ * tema o apertura, resuelve nombres traducidos y formatea tamaños. La página
+ * nunca habla con `PuzzlesCacheService` directamente ni ve una URL.
+ */
+@Injectable({ providedIn: 'root' })
+export class PuzzleStorageService {
+  private puzzlesProvider = inject(PuzzlesProvider);
+  private appService = inject(AppService);
+  private translocoService = inject(TranslocoService);
+
+  private get cacheService() {
+    return this.puzzlesProvider.getCacheService();
+  }
+
+  /**
+   * Lista los archivos descargados agrupados por tema/apertura, de mayor a
+   * menor tamaño: quien entra aquí viene a liberar espacio, así que lo caro
+   * va primero.
+   */
+  async getGroups(): Promise<StorageGroup[]> {
+    const entries = await this.cacheService.listCachedFiles();
+    const groups = new Map<string, StorageGroup>();
+
+    for (const entry of entries) {
+      const { key, kind } = this.resolveGroupKey(entry);
+
+      let group = groups.get(key);
+      if (!group) {
+        group = {
+          key,
+          kind,
+          name: this.resolveGroupName(key, kind),
+          files: [],
+          sizeBytes: 0,
+          sizeUnknown: false,
+        };
+        groups.set(key, group);
+      }
+
+      const sizeUnknown = entry.sizeBytes === undefined;
+      group.files.push({
+        url: entry.key,
+        eloStart: entry.eloStart,
+        eloEnd: entry.eloEnd,
+        eloLabel: this.formatEloRange(entry.eloStart, entry.eloEnd),
+        count: entry.count,
+        sizeBytes: entry.sizeBytes ?? 0,
+        sizeUnknown,
+        timestamp: entry.timestamp,
+      });
+      group.sizeBytes += entry.sizeBytes ?? 0;
+      group.sizeUnknown = group.sizeUnknown || sizeUnknown;
+    }
+
+    const result = [...groups.values()];
+    for (const group of result) {
+      // Dentro de un tema el orden natural es por dificultad, no por tamaño
+      group.files.sort((a, b) => (a.eloStart ?? 0) - (b.eloStart ?? 0));
+    }
+    result.sort((a, b) => b.sizeBytes - a.sizeBytes);
+
+    return result;
+  }
+
+  /** Totales para el resumen de Ajustes. */
+  async getSummary(): Promise<StorageSummary> {
+    return this.cacheService.getStorageSummary();
+  }
+
+  /** Borra un archivo concreto. */
+  async deleteFile(url: string): Promise<void> {
+    await this.cacheService.deleteCachedPuzzles(url);
+  }
+
+  /** Borra todos los archivos de un tema o apertura. */
+  async deleteGroup(group: StorageGroup): Promise<void> {
+    await this.cacheService.deleteCachedFiles(group.files.map((file) => file.url));
+  }
+
+  /**
+   * Borra todo lo almacenado: los archivos de puzzles y el pool de
+   * entrenamiento continuo, que vive en otro store. Si no se vaciara el pool,
+   * "borrar todo" dejaría ~50 puzzles dentro y el total mostrado mentiría.
+   */
+  async deleteAll(): Promise<void> {
+    await this.cacheService.clearCache();
+    await this.cacheService.clearInfinityPool();
+  }
+
+  /**
+   * Formatea bytes con el separador decimal del idioma activo
+   * (18,3 MB en español · 18.3 MB en inglés).
+   */
+  formatBytes(bytes: number): string {
+    if (!bytes || bytes < 0) return '0 KB';
+
+    const locale = this.translocoService.getActiveLang() === 'es' ? 'es-ES' : 'en-US';
+    const units: { limit: number; divisor: number; suffix: string; decimals: number }[] = [
+      { limit: 1024 * 1024, divisor: 1024, suffix: 'KB', decimals: 0 },
+      { limit: 1024 * 1024 * 1024, divisor: 1024 * 1024, suffix: 'MB', decimals: 1 },
+      { limit: Infinity, divisor: 1024 * 1024 * 1024, suffix: 'GB', decimals: 2 },
+    ];
+
+    if (bytes < 1024) {
+      return '< 1 KB';
+    }
+
+    const unit = units.find((candidate) => bytes < candidate.limit) ?? units[units.length - 1];
+    const value = bytes / unit.divisor;
+    const formatted = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: unit.decimals,
+      maximumFractionDigits: unit.decimals,
+    }).format(value);
+
+    return `${formatted} ${unit.suffix}`;
+  }
+
+  /** "1500–1519" (guión largo, como en el diseño). */
+  private formatEloRange(eloStart?: number, eloEnd?: number): string {
+    if (eloStart === undefined || eloEnd === undefined) return '—';
+    return `${eloStart}–${eloEnd}`;
+  }
+
+  private resolveGroupKey(entry: CachedFileIndexEntry): {
+    key: string;
+    kind: StorageGroup['kind'];
+  } {
+    if (entry.theme) return { key: entry.theme, kind: 'theme' };
+    if (entry.opening) return { key: entry.opening, kind: 'opening' };
+    return { key: '__unknown__', kind: 'unknown' };
+  }
+
+  /**
+   * Nombre traducido del tema/apertura. Si el catálogo no lo conoce (tema
+   * nuevo en el CDN, o datos aún sin cargar) se cae al valor interno antes
+   * que dejar la fila sin título.
+   */
+  private resolveGroupName(key: string, kind: StorageGroup['kind']): string {
+    if (kind === 'theme') {
+      return this.appService.getNameThemePuzzleByValue(key) || key;
+    }
+    if (kind === 'opening') {
+      return this.appService.getNameOpeningByValue(key) || key.replace(/_/g, ' ');
+    }
+    return this.translocoService.translate('STORAGE.otherFiles');
+  }
+}

--- a/apps/chessColate/src/assets/i18n/en.json
+++ b/apps/chessColate/src/assets/i18n/en.json
@@ -526,7 +526,32 @@
     "title": "Settings",
     "language": "Language",
     "appearance": "Appearance",
-    "notifications": "Notifications"
+    "notifications": "Notifications",
+    "storage": "Storage"
+  },
+  "STORAGE": {
+    "pageTitle": "Downloaded puzzles",
+    "settingsRowTitle": "Manage downloads",
+    "settingsRowDesc": "See how much space downloaded puzzles take and free it up",
+    "summary": "{{files}} files · {{size}}",
+    "loading": "Calculating…",
+    "empty": "You have no downloaded puzzles. They download on their own as you train.",
+    "intro": "Puzzles are stored on your device so they don't have to be downloaded again. Deleting them doesn't affect your progress or your ELO.",
+    "openings": "Openings",
+    "otherFiles": "Other files",
+    "filesCount": "{{count}} files",
+    "oneFile": "1 file",
+    "puzzlesCount": "{{count}} puzzles",
+    "deleteAll": "Delete all",
+    "confirm": {
+      "delete": "Delete",
+      "fileTitle": "Delete this file?",
+      "fileMessage": "{{name}} · {{eloRange}}. It will be downloaded again when you need it.",
+      "groupTitle": "Delete {{name}}?",
+      "groupMessage": "{{files}} files ({{size}}). They will be downloaded again when you need them.",
+      "allTitle": "Delete everything?",
+      "allMessage": "{{files}} files ({{size}}). You won't lose your progress or your ELO."
+    }
   },
   "TRAINING_REMINDER": {
     "pageTitle": "Reminders",

--- a/apps/chessColate/src/assets/i18n/es.json
+++ b/apps/chessColate/src/assets/i18n/es.json
@@ -526,7 +526,32 @@
     "title": "Ajustes",
     "language": "Idioma",
     "appearance": "Apariencia",
-    "notifications": "Notificaciones"
+    "notifications": "Notificaciones",
+    "storage": "Almacenamiento"
+  },
+  "STORAGE": {
+    "pageTitle": "Puzzles descargados",
+    "settingsRowTitle": "Gestionar descargas",
+    "settingsRowDesc": "Mira cuánto ocupan los puzzles descargados y libera espacio",
+    "summary": "{{files}} archivos · {{size}}",
+    "loading": "Calculando…",
+    "empty": "No tienes puzzles descargados. Se descargan solos cuando entrenas.",
+    "intro": "Los puzzles se guardan en el dispositivo para que no haya que volver a descargarlos. Borrarlos no afecta a tu progreso ni a tu ELO.",
+    "openings": "Aperturas",
+    "otherFiles": "Otros archivos",
+    "filesCount": "{{count}} archivos",
+    "oneFile": "1 archivo",
+    "puzzlesCount": "{{count}} puzzles",
+    "deleteAll": "Borrar todo",
+    "confirm": {
+      "delete": "Borrar",
+      "fileTitle": "¿Borrar este archivo?",
+      "fileMessage": "{{name}} · {{eloRange}}. Se volverá a descargar cuando lo necesites.",
+      "groupTitle": "¿Borrar {{name}}?",
+      "groupMessage": "{{files}} archivos ({{size}}). Se volverán a descargar cuando los necesites.",
+      "allTitle": "¿Borrar todo?",
+      "allMessage": "{{files}} archivos ({{size}}). No pierdes tu progreso ni tu ELO."
+    }
   },
   "TRAINING_REMINDER": {
     "pageTitle": "Recordatorios",

--- a/docs/features/GESTION_DESCARGAS_PUZZLES.md
+++ b/docs/features/GESTION_DESCARGAS_PUZZLES.md
@@ -1,5 +1,10 @@
 # Gestión de Descargas de Puzzles — Feature Document
 
+> ✅ **Implementado.** Este documento es el **diseño original**. Para saber **cómo quedó
+> funcionando** (arquitectura, archivos, decisiones y bordes conocidos), ver
+> **[GESTION_DESCARGAS_PUZZLES_FLOW.md](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md)**.
+> Las seis decisiones abiertas al final se resolvieron **según lo propuesto**.
+
 ## Concepto
 
 Hoy ChessColate descarga archivos de puzzles desde el CDN y los guarda en el dispositivo **de forma completamente invisible**: el usuario nunca ve qué tiene almacenado, cuánto ocupa, ni puede borrarlo. El caché crece silenciosamente sesión tras sesión y la única limpieza es automática (expiración a 1 año, evicción a los 90 días sin uso).

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -13,24 +13,25 @@ El orden busca cuatro cosas, en este equilibrio: **(1)** despachar primero lo de
 | ✅ | — | [Observabilidad — Tracking](../implementado/OBSERVABILITY_TRACKING.md) | Alto (base) | Medio | — |
 | ✅ | — | [Recordatorios de Entrenamiento](../implementado/RECORDATORIOS_ENTRENAMIENTO_FLOW.md) | Alto (retención) | Medio | — |
 | ✅ | — | [Racha de Puzzles](../implementado/RACHA_STREAK_FLOW.md) | Alto (retención) | Medio | `board-puzzle` |
+| ✅ | — | [Gestión de Descargas de Puzzles](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md) | Medio (confianza/espacio) | Bajo-Medio | Caché de `puzzles-provider` (ya existe) |
 | ⬜ | 1 | [Calificar la App (In-App Review)](./CALIFICAR_APP.md) | Alto (negocio) | Bajo | Play Core (plugin nativo) |
-| ⬜ | 2 | [Gestión de Descargas de Puzzles](./GESTION_DESCARGAS_PUZZLES.md) | Medio (confianza/espacio) | Bajo-Medio | Caché de `puzzles-provider` (ya existe) |
-| ⬜ | 3 | [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md) | Medio | Medio | — (crea el util de PGN compartido) |
-| ⬜ | 4 | [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md) | Alto | Medio | #3 (parseo PGN) |
-| ⬜ | 5 | [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md) | Alto | Medio | #4 (set congelado) |
-| ⬜ | 6 | [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md) | Alto (estudio) | Alto | #3 (parseo PGN + navegación) |
-| ⬜ | 7 | [Puzzle Feed](./PUZZLE_FEED.md) | Alto (engagement) | Medio-Alto | — |
-| ⬜ | 8 | [Chess Runner](./CHESS_RUNNER.md) | Medio | Medio | — |
-| ⬜ | 9 | [Game Analytics](./GAME_ANALYTICS.md) | Alto | Alto | APIs externas (chess.com/lichess) |
-| ⬜ | 10 | [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md) | Alto | Alto (Nivel 1) / Muy Alto (Nivel 2) | #9 (ingesta de partidas) + `stockfish-wasm` |
-| ⬜ | 11 | [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md) | Alto | Muy Alto | Backend + matchmaking |
-| ⬜ | 12 | [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md) | Alto (competitivo/viral) | Alto | RTDB + matchmaking (sin backend propio) |
-| ⬜ | 13 | [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md) | Medio (nicho) | Muy Alto | GPS + AR + permisos |
+| ⬜ | 2 | [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md) | Medio | Medio | — (crea el util de PGN compartido) |
+| ⬜ | 3 | [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md) | Alto | Medio | #2 (parseo PGN) |
+| ⬜ | 4 | [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md) | Alto | Medio | #3 (set congelado) |
+| ⬜ | 5 | [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md) | Alto (estudio) | Alto | #2 (parseo PGN + navegación) |
+| ⬜ | 6 | [Puzzle Feed](./PUZZLE_FEED.md) | Alto (engagement) | Medio-Alto | — |
+| ⬜ | 7 | [Chess Runner](./CHESS_RUNNER.md) | Medio | Medio | — |
+| ⬜ | 8 | [Game Analytics](./GAME_ANALYTICS.md) | Alto | Alto | APIs externas (chess.com/lichess) |
+| ⬜ | 9 | [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md) | Alto | Alto (Nivel 1) / Muy Alto (Nivel 2) | #8 (ingesta de partidas) + `stockfish-wasm` |
+| ⬜ | 10 | [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md) | Alto | Muy Alto | Backend + matchmaking |
+| ⬜ | 11 | [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md) | Alto (competitivo/viral) | Alto | RTDB + matchmaking (sin backend propio) |
+| ⬜ | 12 | [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md) | Medio (nicho) | Muy Alto | GPS + AR + permisos |
 
 > ✅ = ya implementado (detalle en [Ya implementado](#ya-implementado)) · ⬜ = pendiente.
 > Las filas con ✅ no llevan número porque ya salieron del orden de trabajo: eran las
 > dos primeras del plan original (**Notificaciones de Entrenamiento** y **Racha de
-> Puzzles**) más la base de observabilidad.
+> Puzzles**) más la base de observabilidad y la **Gestión de Descargas de Puzzles**.
+> Los pendientes se renumeran cuando una feature sale de la lista.
 
 ---
 
@@ -39,40 +40,37 @@ El orden busca cuatro cosas, en este equilibrio: **(1)** despachar primero lo de
 ### 1 · [Calificar la App (In-App Review)](./CALIFICAR_APP.md)
 **Lo más barato con más retorno directo.** Es un servicio pequeño más un plugin nativo: no toca tablero, ni ELO, ni datos de entrenamiento. A cambio mueve la aguja donde más se nota — el rating y el volumen de reseñas de la ficha de Play Store, que es lo que decide si quien te encuentra se instala la app. Además **se apoya en cosas que ya existen**: el récord personal de la Racha y el fin de rutina son justo los picos emocionales donde conviene pedir la reseña.
 
-### 2 · [Gestión de Descargas de Puzzles](./GESTION_DESCARGAS_PUZZLES.md)
-**Cierra un hueco de confianza que hoy está abierto.** La app acumula archivos de puzzles en el dispositivo sin que el usuario lo vea ni pueda vaciarlo; cuando el sistema le enseña "ChessColate: 87 MB", la reacción típica es desinstalar. El esfuerzo es contenido porque **la unidad de descarga ya existe y la URL ya codifica tema y rango de ELO** — se trata sobre todo de listar, mostrar y borrar. Va temprano porque el caché solo crece con el tiempo, y de paso instrumenta cuánto espacio ocupa un usuario real.
-
-### 3 · [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md)
+### 2 · [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md)
 **Cimiento técnico de las tres siguientes.** Introduce el **util de parseo de PGN con `chess.js`** y **generaliza el motor de reproducción** de jugadas (a partir de [`board-puzzle-solution`](../../libs/board/src/lib/board-puzzle-solution/board-puzzle-solution.component.ts)). Es relativamente autocontenido (no toca ELO ni scoring) y deja listo un componente reutilizable.
 
-### 4 · [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md)
-**Reutiliza el parseo PGN de #3** y estrena el patrón de **"set de puzzles congelado y persistido"** (en vez de re-pedirlo al catálogo). Alto valor para entrenadores y estudio dirigido.
+### 3 · [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md)
+**Reutiliza el parseo PGN de #2** y estrena el patrón de **"set de puzzles congelado y persistido"** (en vez de re-pedirlo al catálogo). Alto valor para entrenadores y estudio dirigido.
 
-### 5 · [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md)
-**Reutiliza el "set congelado" de #4** y le añade **vueltas + timing decreciente + comparación entre pasadas**. Al llegar después de #4, gran parte de la persistencia y del juego por set ya está resuelta.
+### 4 · [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md)
+**Reutiliza el "set congelado" de #3** y le añade **vueltas + timing decreciente + comparación entre pasadas**. Al llegar después de #3, gran parte de la persistencia y del juego por set ya está resuelta.
 
-### 6 · [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md)
-**La versión activa de #3**: donde el reproductor deja mirar la partida, el analizador deja intervenirla — ramificar en variantes, comentar posiciones y dibujar encima del tablero (varias "láminas" por posición, alternables). Comparte con #3 el parseo PGN y la navegación, así que llega después; va tras el bloque de estudio (#4–#5) porque es **claramente el más caro de los cuatro**: árbol de variantes, persistencia propia y motor de dibujo sobre `canvas`.
+### 5 · [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md)
+**La versión activa de #2**: donde el reproductor deja mirar la partida, el analizador deja intervenirla — ramificar en variantes, comentar posiciones y dibujar encima del tablero (varias "láminas" por posición, alternables). Comparte con #2 el parseo PGN y la navegación, así que llega después; va tras el bloque de estudio (#3–#4) porque es **claramente el más caro de los cuatro**: árbol de variantes, persistencia propia y motor de dibujo sobre `canvas`.
 
-### 7 · [Puzzle Feed](./PUZZLE_FEED.md)
-**Motor de engagement** estilo TikTok/Reels sobre puzzles. Reutiliza [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) y el catálogo; el algoritmo de recomendación puede empezar **local** (ELO + temas + historial) sin backend. Alto potencial de uso, independiente de #3–#6.
+### 6 · [Puzzle Feed](./PUZZLE_FEED.md)
+**Motor de engagement** estilo TikTok/Reels sobre puzzles. Reutiliza [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) y el catálogo; el algoritmo de recomendación puede empezar **local** (ELO + temas + historial) sin backend. Alto potencial de uso, independiente de #2–#5.
 
-### 8 · [Chess Runner](./CHESS_RUNNER.md)
+### 7 · [Chess Runner](./CHESS_RUNNER.md)
 **Capa de gamificación** (mini-juego previo al puzzle). Autocontenido, sin dependencias de datos externas; encaja cuando ya hay volumen de puzzles jugándose. Esfuerzo medio (animación/gameplay).
 
-### 9 · [Game Analytics](./GAME_ANALYTICS.md)
+### 8 · [Game Analytics](./GAME_ANALYTICS.md)
 **Nuevas libs** (`chess-com-provider`, `lichess-provider`, `game-reporter`) y **APIs externas**. Alto valor pero mayor superficie y dependencia de terceros; es bastante independiente, así que puede solaparse en paralelo con las anteriores si hay capacidad.
 
-### 10 · [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md)
-**Consume directamente la ingesta de #9**: los providers de chess.com/lichess, el caché de partidas y el modelo `ChessGame`. A partir de ahí construye un **perfil de estilo** y un rival jugable que aproxima tu fuerza y tus manías. El **Nivel 1** (perfil estadístico + Stockfish sesgado con [`stockfish-wasm`](../../libs/stockfish-wasm/src/lib/)) es **on-device, sin backend** — de ahí que llegue justo tras #9. El **Nivel 2** (clon neuronal tipo Maia fine-tuneado) es I+D con GPU/backend y **no bloquea** el lanzamiento.
+### 9 · [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md)
+**Consume directamente la ingesta de #8**: los providers de chess.com/lichess, el caché de partidas y el modelo `ChessGame`. A partir de ahí construye un **perfil de estilo** y un rival jugable que aproxima tu fuerza y tus manías. El **Nivel 1** (perfil estadístico + Stockfish sesgado con [`stockfish-wasm`](../../libs/stockfish-wasm/src/lib/)) es **on-device, sin backend** — de ahí que llegue justo tras #8. El **Nivel 2** (clon neuronal tipo Maia fine-tuneado) es I+D con GPU/backend y **no bloquea** el lanzamiento.
 
-### 11 · [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md)
-**PvP asíncrono** con matchmaking, economía de poderes y estado compartido → **requiere backend**. Complejidad alta; conviene atacarlo cuando la base de usuarios (que la Racha y #7 ayudan a crecer) lo justifique.
+### 10 · [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md)
+**PvP asíncrono** con matchmaking, economía de poderes y estado compartido → **requiere backend**. Complejidad alta; conviene atacarlo cuando la base de usuarios (que la Racha y #6 ayudan a crecer) lo justifique.
 
-### 12 · [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md)
-**PvP en tiempo real** estilo [Puzzle Racer de Lichess](https://lichess.org/racer): varios jugadores compiten sobre la **misma secuencia de puzzles** contra el reloj. A diferencia de #11, está diseñado para correr **sin backend propio**: Firebase solo transporta enteros diminutos por un canal efímero de **Realtime Database** y el contenido de los puzzles sale del CDN + caché que ya existe — el objetivo explícito es que **casi no consuma recursos de Firebase** (~10 000 carreras por dólar de ancho de banda). Estrena el bloque compartido de **RTDB + matchmaking client-side** que #11 puede reutilizar. Alto valor competitivo/viral; llega en el clúster PvP porque el matchmaking y la sincronización son la parte más delicada.
+### 11 · [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md)
+**PvP en tiempo real** estilo [Puzzle Racer de Lichess](https://lichess.org/racer): varios jugadores compiten sobre la **misma secuencia de puzzles** contra el reloj. A diferencia de #10, está diseñado para correr **sin backend propio**: Firebase solo transporta enteros diminutos por un canal efímero de **Realtime Database** y el contenido de los puzzles sale del CDN + caché que ya existe — el objetivo explícito es que **casi no consuma recursos de Firebase** (~10 000 carreras por dólar de ancho de banda). Estrena el bloque compartido de **RTDB + matchmaking client-side** que #10 puede reutilizar. Alto valor competitivo/viral; llega en el clúster PvP porque el matchmaking y la sincronización son la parte más delicada.
 
-### 13 · [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md)
+### 12 · [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md)
 **GPS + AR + permisos de cámara/ubicación.** El más caro en hardware/plataforma y el más de nicho. Último, como apuesta diferenciadora una vez consolidado el núcleo.
 
 ---
@@ -81,12 +79,12 @@ El orden busca cuatro cosas, en este equilibrio: **(1)** despachar primero lo de
 
 Conviene tratarlos como piezas transversales, no re-implementarlas por feature:
 
-- **Util de parseo PGN** (`chess.js`) → lo estrena #3 y lo reutilizan #4, #5 y #6. Extraer a [`libs/common-utils`](../../libs/common-utils).
-- **Set de puzzles congelado y persistido por id** → patrón común de #4 y #5 (y posible fuente de sets en #5). Evita el _strip_ actual de `puzzles` al guardar planes.
-- **Motor de reproducción de jugadas** (tablero + secuencia de FEN/SAN + controles) → de #3, reutilizable donde se "reproduzca" una línea; #6 lo extiende con el árbol de variantes.
-- **Board de puzzles** [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) → ya existe; lo consumen la Racha, #4, #5, #7, #8, #12 y #13.
-- **Metadata del caché de puzzles** (tema + rango de ELO + tamaño por archivo descargado) → la estrena #2 y deja medible cuánto espacio ocupa la app.
-- **RTDB + matchmaking client-side** (canal efímero de tiempo real, transacciones de lobby, `onDisconnect`) → lo estrena #12 y lo puede reutilizar #11 (Cuadros de Conquista) para su capa PvP. RTDB no está cableada hoy (solo Firestore).
+- **Util de parseo PGN** (`chess.js`) → lo estrena #2 y lo reutilizan #3, #4 y #5. Extraer a [`libs/common-utils`](../../libs/common-utils).
+- **Set de puzzles congelado y persistido por id** → patrón común de #3 y #4 (y posible fuente de sets en #4). Evita el _strip_ actual de `puzzles` al guardar planes.
+- **Motor de reproducción de jugadas** (tablero + secuencia de FEN/SAN + controles) → de #2, reutilizable donde se "reproduzca" una línea; #5 lo extiende con el árbol de variantes.
+- **Board de puzzles** [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) → ya existe; lo consumen la Racha, #3, #4, #6, #7, #11 y #12.
+- **Metadata del caché de puzzles** (tema + rango de ELO + tamaño por archivo descargado) → **ya existe**: la estrenó la [Gestión de Descargas](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md) y deja medible cuánto espacio ocupa la app.
+- **RTDB + matchmaking client-side** (canal efímero de tiempo real, transacciones de lobby, `onDisconnect`) → lo estrena #11 y lo puede reutilizar #10 (Cuadros de Conquista) para su capa PvP. RTDB no está cableada hoy (solo Firestore).
 - **AnalyticsService** [(catálogo)](../implementado/OBSERVABILITY_TRACKING.md) → todas instrumentan sobre la base ya implementada.
 
 ---
@@ -96,7 +94,7 @@ Conviene tratarlos como piezas transversales, no re-implementarlas por feature:
 - **Estado**: ✅ implementado · ⬜ pendiente.
 - **Valor**: impacto esperado en retención/engagement/diferenciación (o en negocio, en el caso de #1).
 - **Esfuerzo**: tamaño relativo de implementación (incl. infra y plataforma).
-- El orden es una **recomendación**, no un contrato: #9 (Game Analytics) es lo bastante independiente como para paralelizarse; #7 (Puzzle Feed) puede adelantarse si la prioridad es crecimiento antes que las herramientas de estudio (#3–#6).
+- El orden es una **recomendación**, no un contrato: #8 (Game Analytics) es lo bastante independiente como para paralelizarse; #6 (Puzzle Feed) puede adelantarse si la prioridad es crecimiento antes que las herramientas de estudio (#2–#5).
 
 ---
 
@@ -106,3 +104,4 @@ Conviene tratarlos como piezas transversales, no re-implementarlas por feature:
 - [Recordatorios de Entrenamiento](../implementado/RECORDATORIOS_ENTRENAMIENTO_FLOW.md) — recordatorio automático que aprende tu hora habitual, más alarmas manuales por día. Idea original en [`NOTIFICACIONES_ENTRENAMIENTO.md`](./NOTIFICACIONES_ENTRENAMIENTO.md).
 - [Racha de Puzzles](../implementado/RACHA_STREAK_FLOW.md) — modo de muerte súbita con dificultad creciente y récord personal. Idea original en [`RACHA_STREAK.md`](./RACHA_STREAK.md).
 - [Pool de Puzzles del Entrenamiento Continuo](../implementado/INFINITY_PUZZLE_POOL_FLOW.md) — 50 puzzles pre-cargados en IndexedDB que comparten la tarjeta del home y la sesión de entrenamiento continuo, para no repetir peticiones al CDN.
+- [Gestión de Descargas de Puzzles](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md) — pantalla de Almacenamiento que lista los archivos descargados por tema y rango de ELO, con su tamaño, y permite borrarlos. Idea original en [`GESTION_DESCARGAS_PUZZLES.md`](./GESTION_DESCARGAS_PUZZLES.md).

--- a/docs/implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md
+++ b/docs/implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md
@@ -1,0 +1,200 @@
+# Flujo de la gestión de descargas de puzzles
+
+La app descarga archivos de puzzles del CDN y los guarda en el dispositivo.
+Antes esto era **invisible**: el usuario no veía qué tenía guardado, cuánto
+ocupaba, ni podía borrarlo. Ahora hay una pantalla que lo lista y permite
+vaciarlo.
+
+> Este documento describe cómo funciona lo implementado. La idea original
+> (planificación) está en
+> [`../features/GESTION_DESCARGAS_PUZZLES.md`](../features/GESTION_DESCARGAS_PUZZLES.md).
+
+---
+
+## Qué ve el usuario
+
+**Ajustes** gana una sección de **Almacenamiento** con el resumen
+("124 archivos · 18,3 MB") y un acceso a la pantalla de gestión
+(`/settings/storage`), donde los archivos aparecen **agrupados por tema o
+apertura** y ordenados de mayor a menor tamaño — quien entra viene a liberar
+espacio, así que lo caro va primero.
+
+```
+Puzzles descargados
+124 archivos · 18,3 MB                [Borrar todo]
+─────────────────────────────────────────────────
+▸ Mate en 2            31 archivos · 5,4 MB     🗑
+▾ Horquilla            12 archivos · 2,1 MB     🗑
+    1480–1499 · 200 puzzles · 148 KB            🗑
+    1500–1519 · 200 puzzles · 151 KB            🗑
+▸ Defensa Siciliana     8 archivos · 1,3 MB     🗑   (Aperturas)
+```
+
+Tres niveles de borrado — un archivo, un grupo, todo — cada uno con su
+confirmación. **El copy siempre recuerda que no se pierde progreso ni ELO**,
+porque es la duda número uno ante un botón de borrar y aquí la respuesta es
+honesta: todo lo que se lista es caché. Tras borrar, la lista se refresca sola;
+no hay toast, la lista encogiendo es el feedback.
+
+Si no hay nada descargado: *"No tienes puzzles descargados. Se descargan solos
+cuando entrenas."* Sin CTA — pre-descargar es otra feature, deliberadamente
+fuera de alcance.
+
+**Nunca se muestra una URL.** El usuario ve "Mate en 2 · 1500–1519".
+
+## La unidad: un archivo = un tema × una banda de ELO
+
+No hizo falta cambiar el backend ni el formato de los archivos porque **la URL
+del CDN ya codifica tema y rango de ELO**:
+
+```
+…/puzzlesFilesThemes/fork/fork_1500_1519.json
+                     └tema┘ └tema┘└ rango  ┘
+```
+
+De ahí sale [`parsePuzzleUrl()`](../../libs/puzzles-provider/src/lib/utils.ts),
+la inversa de `buildPuzzleUrl`. El nombre del tema/apertura se toma de **la
+carpeta contenedora**, no del nombre del archivo: los valores de apertura llevan
+guiones bajos (`Sicilian_Defense`) y partir el nombre sería ambiguo.
+
+`getCachedUrlsMatchingElo()` ahora también lo usa, con lo que desapareció el
+`eloEnd = eloStart + 19` hardcodeado que tenía.
+
+## Dónde vive el dato
+
+Todo está en **IndexedDB** (`ChessParkPuzzlesDB`), envuelto por
+[`PuzzlesCacheService`](../../libs/puzzles-provider/src/lib/cache.service.ts):
+
+| Store | Contenido |
+|---|---|
+| `puzzlesCache` | `{ url, puzzles, timestamp, lastAccessedAt }` — pesado |
+| `puzzlesIndex` | `CachedFileIndexEntry` — ligero, es lo que lee la pantalla |
+| `infinityPool` | el pool del entrenamiento continuo |
+
+La metadata vive en **el índice**, no en el caché: leer las 124 entradas de
+`puzzlesCache` para pintar una lista significaría deserializar ~18 MB de puzzles.
+
+```ts
+interface CachedFileIndexEntry {
+  key: string;        // URL — misma clave que puzzlesCache
+  timestamp: number;  // fecha de descarga
+  theme?: string;
+  opening?: string;
+  eloStart?: number;
+  eloEnd?: number;
+  count?: number;     // nº de puzzles
+  sizeBytes?: number; // tamaño aproximado
+}
+```
+
+**No se subió `DB_VERSION`**: IndexedDB no impone esquema por registro, así que
+añadir campos a los objetos de un store existente no requiere `onupgradeneeded`.
+Solo haría falta para crear un índice IDB nuevo, y con ~124 entradas ordenar en
+memoria es gratis.
+
+### Cómo se llena la metadata
+
+- **Al descargar**: `cachePuzzles()` escribe tema/apertura, rango, `count` y
+  `sizeBytes` junto a la entrada del índice. No cambió su firma — todo se deriva
+  de la URL y de los puzzles que ya recibe.
+- **En dispositivos que ya tenían caché**: las entradas antiguas no traen
+  `count` ni `sizeBytes`. `listCachedFiles()` los completa **de forma perezosa
+  la primera vez** (`backfillIndexMetadata`) y los persiste, así que se paga una
+  sola vez por archivo. Por eso la pantalla muestra un **skeleton**, no un
+  spinner bloqueante.
+- Si el backfill falla, la fila se muestra **sin tamaño (`—`)** en vez de dejar
+  la lista vacía. Solo se descartan entradas cuando el recorrido completó y se
+  sabe con certeza que están huérfanas (en el índice pero no en el caché); esas
+  además se limpian del índice.
+
+`sizeBytes` es `JSON.stringify(puzzles).length`: el tamaño del JSON, no lo que
+IndexedDB reserva en disco. Se eligió el dato exacto sobre una estimación por
+media porque **inventar un número en una pantalla cuyo propósito es la
+transparencia sería contradictorio**; se calcula una vez por archivo, en la
+escritura fire-and-forget del caché.
+
+## Arquitectura
+
+```
+storage.page.ts            (lista, confirmaciones, analytics)
+      │
+      ▼
+PuzzleStorageService       (agrupa, traduce, formatea bytes)   ← fachada
+      │
+      ▼
+PuzzlesCacheService        (IndexedDB)
+```
+
+La página **nunca habla con `PuzzlesCacheService`** ni ve una URL, mismo
+principio de fachada que el `AnalyticsService`. La fachada resuelve los nombres
+traducidos vía `AppService` (`themes-puzzle.json` / `openings.json`) y cae al
+valor interno si el catálogo no conoce un tema — mejor un slug que una fila sin
+título.
+
+Métodos nuevos en la lib:
+
+```ts
+listCachedFiles(): Promise<CachedFileIndexEntry[]>   // + backfill perezoso
+deleteCachedFiles(urls: string[]): Promise<void>     // borrar un grupo, 1 transacción
+getStorageSummary(): Promise<StorageSummary>         // { files, sizeBytes }
+clearInfinityPool(): Promise<void>
+```
+
+## Decisiones
+
+| Decisión | Cómo quedó | Por qué |
+|---|---|---|
+| **"Borrar todo" y el pool de infinity** | Lo vacía también | El pool vive en otro store y `clearCache()` no lo toca. Si no se borrara, "borrar todo" dejaría ~50 puzzles dentro y el total mostrado mentiría. Se reconstruye solo en la siguiente entrada al home. |
+| **Aperturas** | Sí, un grupo por apertura | Si no, el total no cuadraría con lo que ocupa de verdad y quedarían archivos imborrables desde la UI. |
+| **Tamaño** | Exacto (`JSON.stringify`) | Coherencia con el propósito de la pantalla. |
+| **Fecha de descarga por fila** | No | Añade ruido a una fila ya densa. El dato está en `timestamp` si alguien lo pide. |
+| **Orden** | Tamaño descendente | El objetivo es liberar espacio. |
+| **Entrada** | Ajustes, junto a Idioma y Notificaciones | — |
+
+La sección **no está condicionada a nativo** (a diferencia de Notificaciones):
+el caché de IndexedDB existe igual en web/PWA.
+
+## Bordes conocidos
+
+- **Borrar durante un entrenamiento en curso** no rompe la sesión: los puzzles
+  del bloque activo ya están en memoria. La reposición del entrenamiento
+  continuo volvería a descargar, que es exactamente lo que el usuario pidió.
+- **Escritura fire-and-forget**: un archivo recién descargado puede tardar un
+  instante en aparecer en la lista. Irrelevante en la práctica — a esta pantalla
+  se entra desde Ajustes, no en mitad de una descarga.
+- **Sin IndexedDB no hay caché** (el "fallback a localStorage" que promete el
+  docstring del servicio nunca existió). En ese caso la pantalla muestra el
+  estado vacío, no rompe.
+- `sizeBytes` es aproximado y se comunica como tal; no se promete exactitud al
+  byte.
+
+## Analítica
+
+Cuatro eventos, catalogados en
+[OBSERVABILITY_REFERENCIA](./OBSERVABILITY_REFERENCIA.md#6-catálogo-de-eventos-as-built):
+`puzzle_storage_opened`, `puzzle_storage_file_deleted`,
+`puzzle_storage_theme_deleted` y `puzzle_storage_cleared`.
+
+El más valioso es **`puzzle_storage_opened`**: es la primera vez que se mide
+cuánto caché acumula un usuario real. Si la mediana resulta ser de pocos MB, la
+evicción automática (90 días sin uso) ya funciona y esta pantalla es sobre todo
+confianza; si hay cola larga en decenas de MB, hay que revisar los umbrales de
+`CACHE_STALE_THRESHOLD_MS`.
+
+## Archivos
+
+| Archivo | Rol |
+|---|---|
+| [`libs/puzzles-provider/src/lib/utils.ts`](../../libs/puzzles-provider/src/lib/utils.ts) | `parsePuzzleUrl`, `estimateSizeBytes` |
+| [`libs/puzzles-provider/src/lib/cache.service.ts`](../../libs/puzzles-provider/src/lib/cache.service.ts) | listado, backfill, borrado múltiple, resumen |
+| [`libs/puzzles-provider/src/lib/types.ts`](../../libs/puzzles-provider/src/lib/types.ts) | `CachedFileIndexEntry`, `StorageSummary` |
+| [`apps/chessColate/src/app/services/puzzle-storage.service.ts`](../../apps/chessColate/src/app/services/puzzle-storage.service.ts) | fachada: agrupar, traducir, formatear |
+| [`apps/chessColate/src/app/pages/settings/storage/`](../../apps/chessColate/src/app/pages/settings/storage/) | pantalla de gestión |
+| [`apps/chessColate/src/app/pages/settings/settings.page.html`](../../apps/chessColate/src/app/pages/settings/settings.page.html) | sección de Almacenamiento |
+| `assets/i18n/{es,en}.json` | claves `SETTINGS.storage` y `STORAGE.*` |
+
+## Fuera de alcance
+
+Pre-descarga / modo offline explícito, límite de caché configurable con LRU, y
+tocar los umbrales de expiración (1 año) o de evicción (90 días). Las tres se
+deciden mejor **con los datos** que ahora empieza a dar `puzzle_storage_opened`.

--- a/docs/implementado/OBSERVABILITY_REFERENCIA.md
+++ b/docs/implementado/OBSERVABILITY_REFERENCIA.md
@@ -86,6 +86,10 @@ legible). El resto son **acciones semánticas**. Nombres y params en `snake_case
 | `public_plan_saved` | guarda/quita una pública | `plan_uid`, `saved` | `public-plans.component.ts` |
 | `language_changed` | cambia idioma | `from`, `to` | `settings.page.ts` |
 | `donation_completed` | donación exitosa | `value`, `currency`, `item_id` | `donation.page.ts` |
+| `puzzle_storage_opened` | abre la gestión de descargas | `files_count`, `size_mb` | `settings/storage/storage.page.ts` |
+| `puzzle_storage_file_deleted` | borra un archivo | `theme` (tema o apertura), `elo_start` | `settings/storage/storage.page.ts` |
+| `puzzle_storage_theme_deleted` | borra un tema/apertura entero | `theme`, `files_count`, `size_mb` | `settings/storage/storage.page.ts` |
+| `puzzle_storage_cleared` | borra todo lo descargado | `files_count`, `size_mb` | `settings/storage/storage.page.ts` |
 
 \* `routine_uid`/`author_uid` solo en rutinas custom/públicas.
 

--- a/libs/puzzles-provider/README.md
+++ b/libs/puzzles-provider/README.md
@@ -221,6 +221,33 @@ Para mejorar significativamente el rendimiento, la librería procesa múltiples 
 - No bloquea la respuesta al cachear
 - Las verificaciones de caché se realizan en paralelo sin afectar las descargas
 
+### Inspeccionar y vaciar lo descargado
+
+Para construir una pantalla de "cuánto ocupa esto y cómo lo borro", el servicio
+de caché (`provider.getCacheService()`) expone:
+
+```ts
+// Lista los archivos guardados con su metadata: tema o apertura, rango de ELO,
+// nº de puzzles y tamaño aproximado. Solo lee el índice, no los puzzles.
+await cacheService.listCachedFiles();   // CachedFileIndexEntry[]
+
+// Totales agregados
+await cacheService.getStorageSummary(); // { files, sizeBytes }
+
+// Borrado
+await cacheService.deleteCachedPuzzles(url);   // uno
+await cacheService.deleteCachedFiles(urls);    // varios, en una transacción
+await cacheService.clearCache();               // todos los archivos
+await cacheService.clearInfinityPool();        // el pool de entrenamiento continuo
+```
+
+El tema/apertura y el rango de ELO salen de la propia URL con `parsePuzzleUrl()`,
+la inversa de `buildPuzzleUrl()`. Las entradas guardadas antes de existir esta
+metadata la completan de forma perezosa la primera vez que se listan.
+
+> `getCacheSize()` devuelve un **conteo de entradas**, no bytes, pese a su
+> nombre. Para bytes usar `getStorageSummary()`.
+
 ## Cómo Funciona Internamente
 
 ### Flujo de Obtención de Puzzles

--- a/libs/puzzles-provider/src/index.ts
+++ b/libs/puzzles-provider/src/index.ts
@@ -12,6 +12,8 @@ export type {
   PuzzlesIndex,
   PuzzlesProviderConfig,
   CacheEntry,
+  CachedFileIndexEntry,
+  StorageSummary,
   InfinityPoolEntry,
 } from './lib/types';
 
@@ -28,6 +30,8 @@ export {
   getRepoBase,
   getEloRange,
   buildPuzzleUrl,
+  parsePuzzleUrl,
+  estimateSizeBytes,
   shuffleArray,
   dedupeByUid,
   filterByColor,
@@ -36,6 +40,8 @@ export {
   filterEloSequenceByManifest,
   limitPuzzleCount,
 } from './lib/utils';
+
+export type { ParsedPuzzleUrl } from './lib/utils';
 
 // Exportar utilidades del manifiesto de combinaciones válidas
 export {

--- a/libs/puzzles-provider/src/lib/cache.service.ts
+++ b/libs/puzzles-provider/src/lib/cache.service.ts
@@ -1,5 +1,12 @@
 import { DEFAULT_CONFIG } from './constants';
-import { CacheEntry, InfinityPoolEntry, Puzzle } from './types';
+import {
+  CacheEntry,
+  CachedFileIndexEntry,
+  InfinityPoolEntry,
+  Puzzle,
+  StorageSummary,
+} from './types';
+import { estimateSizeBytes, parsePuzzleUrl } from './utils';
 
 /**
  * Servicio de caché para almacenar puzzles localmente
@@ -176,9 +183,21 @@ export class PuzzlesCacheService {
       const indexStore = transaction.objectStore(this.INDEX_STORE_NAME);
 
       store.put(entry);
-      
-      // Actualizar índice de URLs cacheadas
-      indexStore.put({ key: url, timestamp: entry.timestamp });
+
+      // Actualizar índice de URLs cacheadas, con la metadata que alimenta la
+      // pantalla de gestión de descargas (tema/apertura y ELO salen de la URL)
+      const meta = parsePuzzleUrl(url);
+      const indexEntry: CachedFileIndexEntry = {
+        key: url,
+        timestamp: entry.timestamp,
+        theme: meta?.theme,
+        opening: meta?.opening,
+        eloStart: meta?.eloStart,
+        eloEnd: meta?.eloEnd,
+        count: puzzles.length,
+        sizeBytes: estimateSizeBytes(puzzles),
+      };
+      indexStore.put(indexEntry);
 
       return new Promise((resolve, reject) => {
         transaction.oncomplete = () => resolve();
@@ -236,6 +255,193 @@ export class PuzzlesCacheService {
     } catch (error) {
       console.error('Error en clearCache:', error);
     }
+  }
+
+  /**
+   * Borra varios archivos cacheados en una sola transacción.
+   * Pensado para "borrar todos los archivos de un tema".
+   */
+  async deleteCachedFiles(urls: string[]): Promise<void> {
+    if (!this.db || urls.length === 0) return;
+
+    try {
+      const transaction = this.db.transaction([this.STORE_NAME, this.INDEX_STORE_NAME], 'readwrite');
+      const store = transaction.objectStore(this.STORE_NAME);
+      const indexStore = transaction.objectStore(this.INDEX_STORE_NAME);
+
+      for (const url of urls) {
+        store.delete(url);
+        indexStore.delete(url);
+      }
+
+      return new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+      });
+    } catch (error) {
+      console.error('[PuzzlesCacheService] Error en deleteCachedFiles:', error);
+    }
+  }
+
+  /**
+   * Lista todos los archivos cacheados con su metadata, para la pantalla de
+   * gestión de descargas.
+   *
+   * Lee solo el índice (pequeño): traer `puzzlesCache` entero para pintar una
+   * lista significaría deserializar todos los puzzles. Tema/apertura y ELO se
+   * derivan siempre de la URL; `count`/`sizeBytes` faltantes en entradas
+   * antiguas se completan una única vez (ver `backfillIndexMetadata`).
+   */
+  async listCachedFiles(): Promise<CachedFileIndexEntry[]> {
+    if (!this.enableCache || !this.db) return [];
+
+    try {
+      const entries = await this.getAllIndexEntries();
+
+      const enriched = entries.map((entry) => {
+        const meta = parsePuzzleUrl(entry.key);
+        return {
+          ...entry,
+          theme: entry.theme ?? meta?.theme,
+          opening: entry.opening ?? meta?.opening,
+          eloStart: entry.eloStart ?? meta?.eloStart,
+          eloEnd: entry.eloEnd ?? meta?.eloEnd,
+        } as CachedFileIndexEntry;
+      });
+
+      const pending = enriched.filter(
+        (entry) => entry.count === undefined || entry.sizeBytes === undefined
+      );
+
+      if (pending.length === 0) return enriched;
+
+      // Si el backfill falla, la lista se muestra igual (sin tamaño) antes que
+      // dejar al usuario con una pantalla vacía
+      const orphans = await this.backfillIndexMetadata(pending);
+      return enriched.filter((entry) => !orphans.has(entry.key));
+    } catch (error) {
+      console.error('[PuzzlesCacheService] Error en listCachedFiles:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Totales agregados del caché: nº de archivos y bytes aproximados.
+   */
+  async getStorageSummary(): Promise<StorageSummary> {
+    const files = await this.listCachedFiles();
+    return {
+      files: files.length,
+      sizeBytes: files.reduce((total, entry) => total + (entry.sizeBytes ?? 0), 0),
+    };
+  }
+
+  /**
+   * Vacía el pool de puzzles de entrenamiento continuo (infinity).
+   * Vive en su propio store, así que `clearCache()` no lo toca: se llama
+   * aparte desde "borrar todo" para que no quede nada almacenado.
+   */
+  async clearInfinityPool(): Promise<void> {
+    if (!this.db) return;
+    if (!this.db.objectStoreNames.contains(this.POOL_STORE_NAME)) return;
+
+    try {
+      const transaction = this.db.transaction([this.POOL_STORE_NAME], 'readwrite');
+      transaction.objectStore(this.POOL_STORE_NAME).clear();
+
+      return new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+      });
+    } catch (error) {
+      console.error('[PuzzlesCacheService] Error en clearInfinityPool:', error);
+    }
+  }
+
+  /**
+   * Lee el store del índice completo
+   */
+  private async getAllIndexEntries(): Promise<CachedFileIndexEntry[]> {
+    if (!this.db) return [];
+
+    const transaction = this.db.transaction([this.INDEX_STORE_NAME], 'readonly');
+    const store = transaction.objectStore(this.INDEX_STORE_NAME);
+
+    return new Promise((resolve, reject) => {
+      const request = store.getAll();
+      request.onsuccess = () => resolve((request.result ?? []) as CachedFileIndexEntry[]);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  /**
+   * Completa `count` y `sizeBytes` de entradas del índice escritas antes de que
+   * existiera esa metadata, y persiste el resultado para no repetir el trabajo.
+   *
+   * Recorre `puzzlesCache` con un único cursor (una sola transacción, sin
+   * `await` intermedios que la dejarían expirar) y muta las entradas recibidas.
+   * Devuelve las URLs que están en el índice pero no en el caché: entradas
+   * huérfanas, que se eliminan del índice y no deben mostrarse.
+   */
+  private async backfillIndexMetadata(
+    entries: CachedFileIndexEntry[]
+  ): Promise<Set<string>> {
+    const orphans = new Set(entries.map((entry) => entry.key));
+    if (!this.db) return orphans;
+
+    const byUrl = new Map(entries.map((entry) => [entry.key, entry]));
+    let scanCompleted = false;
+
+    try {
+      const readTx = this.db.transaction([this.STORE_NAME], 'readonly');
+      const store = readTx.objectStore(this.STORE_NAME);
+
+      await new Promise<void>((resolve, reject) => {
+        const cursorReq = store.openCursor();
+        cursorReq.onsuccess = (event) => {
+          const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+          if (!cursor) {
+            resolve();
+            return;
+          }
+
+          const cacheEntry: CacheEntry = cursor.value;
+          const indexEntry = byUrl.get(cacheEntry.url);
+          if (indexEntry) {
+            indexEntry.count = cacheEntry.puzzles?.length ?? 0;
+            indexEntry.sizeBytes = estimateSizeBytes(cacheEntry.puzzles ?? []);
+            orphans.delete(cacheEntry.url);
+          }
+
+          cursor.continue();
+        };
+        cursorReq.onerror = () => reject(cursorReq.error);
+      });
+
+      scanCompleted = true;
+
+      const writeTx = this.db.transaction([this.INDEX_STORE_NAME], 'readwrite');
+      const indexStore = writeTx.objectStore(this.INDEX_STORE_NAME);
+      for (const entry of entries) {
+        if (orphans.has(entry.key)) {
+          indexStore.delete(entry.key);
+        } else {
+          indexStore.put(entry);
+        }
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        writeTx.oncomplete = () => resolve();
+        writeTx.onerror = () => reject(writeTx.error);
+      });
+    } catch (error) {
+      console.error('[PuzzlesCacheService] Error en backfillIndexMetadata:', error);
+      // Sin recorrido completo no se sabe qué falta de verdad: mejor listar
+      // los archivos sin tamaño que hacer desaparecer la lista entera
+      if (!scanCompleted) return new Set();
+    }
+
+    return orphans;
   }
 
   /**
@@ -425,15 +631,11 @@ export class PuzzlesCacheService {
       const min = targetElo - tolerance;
       const max = targetElo + tolerance;
 
-      // Parsear ELO de la URL: patrón _(\d+)_\d+\.json al final del nombre de archivo
-      const eloPattern = /_(\d+)_\d+\.json$/;
       return allKeys.filter((url) => {
-        const match = url.match(eloPattern);
-        if (!match) return false;
-        const eloStart = parseInt(match[1], 10);
-        const eloEnd = eloStart + 19;
+        const parsed = parsePuzzleUrl(url);
+        if (!parsed) return false;
         // El rango [eloStart, eloEnd] se solapa con [min, max]
-        return eloStart <= max && eloEnd >= min;
+        return parsed.eloStart <= max && parsed.eloEnd >= min;
       });
     } catch (error) {
       console.error('[PuzzlesCacheService] Error en getCachedUrlsMatchingElo:', error);

--- a/libs/puzzles-provider/src/lib/types.ts
+++ b/libs/puzzles-provider/src/lib/types.ts
@@ -90,6 +90,37 @@ export interface CacheEntry {
 }
 
 /**
+ * Entrada del índice de archivos cacheados.
+ *
+ * Vive en el store `puzzlesIndex`, que es pequeño y se puede leer entero sin
+ * traer los puzzles a memoria. Todos los campos de metadata son opcionales
+ * a propósito: las entradas escritas antes de existir esta metadata no los
+ * tienen y se completan de forma perezosa al listar.
+ */
+export interface CachedFileIndexEntry {
+  /** URL del archivo — misma clave que en `puzzlesCache` */
+  key: string;
+  /** Fecha de descarga */
+  timestamp: number;
+  theme?: string;
+  opening?: string;
+  eloStart?: number;
+  eloEnd?: number;
+  /** Nº de puzzles del archivo */
+  count?: number;
+  /** Tamaño aproximado en bytes */
+  sizeBytes?: number;
+}
+
+/**
+ * Totales agregados del caché de puzzles
+ */
+export interface StorageSummary {
+  files: number;
+  sizeBytes: number;
+}
+
+/**
  * Entrada del pool de puzzles de entrenamiento continuo (infinity)
  */
 export interface InfinityPoolEntry {

--- a/libs/puzzles-provider/src/lib/utils.spec.ts
+++ b/libs/puzzles-provider/src/lib/utils.spec.ts
@@ -1,0 +1,67 @@
+import { buildPuzzleUrl, estimateSizeBytes, parsePuzzleUrl } from './utils';
+import { ELO_CONSTANTS } from './constants';
+import { Puzzle } from './types';
+
+const CDN = 'https://cdn.jsdelivr.net/gh';
+const USER = 'json-alzate';
+
+describe('parsePuzzleUrl', () => {
+  it('extrae tema y rango de ELO de una URL de tema', () => {
+    const url = buildPuzzleUrl(CDN, USER, 1500, 'fork');
+
+    expect(parsePuzzleUrl(url)).toEqual({
+      theme: 'fork',
+      opening: undefined,
+      eloStart: 1500,
+      eloEnd: 1519,
+    });
+  });
+
+  it('extrae la apertura sin confundirse con sus guiones bajos', () => {
+    const url = buildPuzzleUrl(CDN, USER, 1720, undefined, 'Sicilian_Defense');
+
+    expect(parsePuzzleUrl(url)).toEqual({
+      theme: undefined,
+      opening: 'Sicilian_Defense',
+      eloStart: 1720,
+      eloEnd: 1739,
+    });
+  });
+
+  it('es la inversa de buildPuzzleUrl para todo el rango de ELO', () => {
+    for (let elo = ELO_CONSTANTS.MIN_ELO; elo <= ELO_CONSTANTS.MAX_ELO; elo += ELO_CONSTANTS.ELO_STEP) {
+      const url = buildPuzzleUrl(CDN, USER, elo, 'mateIn2');
+      const parsed = parsePuzzleUrl(url);
+
+      expect(parsed?.theme).toBe('mateIn2');
+      expect(parsed?.eloStart).toBe(elo);
+      expect(parsed?.eloEnd).toBe(elo + 19);
+    }
+  });
+
+  it('devuelve null si la URL no tiene rango de ELO', () => {
+    expect(parsePuzzleUrl('https://cdn.jsdelivr.net/gh/json-alzate/repo/algo.json')).toBeNull();
+  });
+
+  it('recupera el rango de ELO aunque cambie la estructura de carpetas', () => {
+    const parsed = parsePuzzleUrl('https://otro-cdn/loquesea/fork_1500_1519.json');
+
+    expect(parsed).toEqual({ eloStart: 1500, eloEnd: 1519 });
+  });
+});
+
+describe('estimateSizeBytes', () => {
+  it('crece con el número de puzzles', () => {
+    const puzzle = { uid: '00001', fen: '8/8/8/8/8/8/8/K6k w - - 0 1', moves: 'a1a2' } as Puzzle;
+
+    const one = estimateSizeBytes([puzzle]);
+    const three = estimateSizeBytes([puzzle, puzzle, puzzle]);
+
+    expect(one).toBeGreaterThan(0);
+    expect(three).toBeGreaterThan(one);
+  });
+
+  it('no falla con una lista vacía', () => {
+    expect(estimateSizeBytes([])).toBe(2); // '[]'
+  });
+});

--- a/libs/puzzles-provider/src/lib/utils.ts
+++ b/libs/puzzles-provider/src/lib/utils.ts
@@ -65,6 +65,66 @@ export function buildPuzzleUrl(
 }
 
 /**
+ * Datos extraídos de una URL de archivo de puzzles
+ */
+export interface ParsedPuzzleUrl {
+  /** Tema del archivo (indefinido si el archivo es de una apertura) */
+  theme?: string;
+  /** Familia de apertura (indefinida si el archivo es de un tema) */
+  opening?: string;
+  eloStart: number;
+  eloEnd: number;
+}
+
+/**
+ * Inversa de `buildPuzzleUrl`: extrae tema/apertura y rango de ELO de una URL
+ * del CDN. La carpeta contenedora es la fuente del nombre (los valores de
+ * apertura llevan guiones bajos, así que partir el nombre del archivo sería
+ * ambiguo).
+ *
+ * Devuelve `null` si la URL no sigue el patrón conocido.
+ */
+export function parsePuzzleUrl(url: string): ParsedPuzzleUrl | null {
+  const match = url.match(
+    /\/puzzlesFiles(Themes|Openings)\/([^/]+)\/[^/]+_(\d+)_(\d+)\.json$/
+  );
+
+  if (match) {
+    const isTheme = match[1] === 'Themes';
+    return {
+      theme: isTheme ? match[2] : undefined,
+      opening: isTheme ? undefined : match[2],
+      eloStart: parseInt(match[3], 10),
+      eloEnd: parseInt(match[4], 10),
+    };
+  }
+
+  // Fallback: al menos el rango de ELO, que es lo que necesita el filtrado
+  const eloMatch = url.match(/_(\d+)_(\d+)\.json$/);
+  if (!eloMatch) return null;
+
+  return {
+    eloStart: parseInt(eloMatch[1], 10),
+    eloEnd: parseInt(eloMatch[2], 10),
+  };
+}
+
+/**
+ * Tamaño aproximado en bytes que ocupa un conjunto de puzzles.
+ *
+ * Es el tamaño del JSON serializado, no lo que IndexedDB reserva en disco
+ * (el structured clone añade su propio overhead). Suficiente para una pantalla
+ * de "cuánto ocupa esto", y honesto siempre que se comunique como aproximado.
+ */
+export function estimateSizeBytes(puzzles: Puzzle[]): number {
+  try {
+    return JSON.stringify(puzzles).length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * Mezcla un array de puzzles usando el algoritmo Fisher-Yates
  */
 export function shuffleArray<T>(array: T[]): T[] {


### PR DESCRIPTION
Los archivos de puzzles se acumulaban en el dispositivo sin que el usuario pudiera verlos ni vaciarlos. Ajustes gana una sección de Almacenamiento con el total, y una pantalla en /settings/storage que los lista agrupados por tema o apertura, ordenados por tamaño, con borrado en tres niveles (archivo, grupo, todo) y confirmación que aclara que no se pierde progreso.

En la lib de puzzles:
- parsePuzzleUrl(): tema/apertura y rango de ELO a partir de la URL del CDN. getCachedUrlsMatchingElo lo reutiliza y pierde el "+ 19" hardcodeado.
- El índice del caché guarda tema, rango, nº de puzzles y tamaño al descargar; lo ya descargado se completa de forma perezosa al listar.
- listCachedFiles(), deleteCachedFiles(), getStorageSummary() y clearInfinityPool(). No hizo falta subir DB_VERSION.

"Borrar todo" vacía también el pool del entrenamiento continuo, que vive en otro store: si no, el total mostrado mentiría. Se reconstruye solo.

Incluye los 4 eventos de analítica del catálogo, entre ellos puzzle_storage_opened, que es la primera medida de cuánto caché acumula un usuario real.