### PR TITLE
feat(reseñas): invitación a calificar la app tras una buena rutina

### DIFF
--- a/apps/chessColate/android/app/capacitor.build.gradle
+++ b/apps/chessColate/android/app/capacitor.build.gradle
@@ -9,6 +9,7 @@ android {
 
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
+    implementation project(':capacitor-community-in-app-review')
     implementation project(':capacitor-firebase-analytics')
     implementation project(':capacitor-firebase-authentication')
     implementation project(':capacitor-firebase-crashlytics')

--- a/apps/chessColate/android/capacitor.settings.gradle
+++ b/apps/chessColate/android/capacitor.settings.gradle
@@ -2,6 +2,9 @@
 include ':capacitor-android'
 project(':capacitor-android').projectDir = new File('../../../node_modules/@capacitor/android/capacitor')
 
+include ':capacitor-community-in-app-review'
+project(':capacitor-community-in-app-review').projectDir = new File('../../../node_modules/@capacitor-community/in-app-review/android')
+
 include ':capacitor-firebase-analytics'
 project(':capacitor-firebase-analytics').projectDir = new File('../../../node_modules/@capacitor-firebase/analytics/android')
 

--- a/apps/chessColate/package.json
+++ b/apps/chessColate/package.json
@@ -8,6 +8,7 @@
     "android:run": "npx cap run android"
   },
   "dependencies": {
+    "@capacitor-community/in-app-review": "^7.1.0",
     "@capacitor-firebase/analytics": "^7.5.0",
     "@capacitor-firebase/authentication": "^7.4.0",
     "@capacitor-firebase/crashlytics": "^7.5.0",

--- a/apps/chessColate/src/app/pages/puzzles/containers/plan-played/plan-played.component.ts
+++ b/apps/chessColate/src/app/pages/puzzles/containers/plan-played/plan-played.component.ts
@@ -23,6 +23,8 @@ import { PlanService } from '@services/plan.service';
 import { PlanStorageService } from '@services/plan-storage.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { TrainingReminderService } from '@services/training-reminder.service';
+import { AppReviewService } from '@services/app-review.service';
+import { routineAccuracy } from '@services/app-review.util';
 import { LoadingController } from '@ionic/angular/standalone';
 
 import { BoardPuzzleSolutionComponent } from '@chesspark/board';
@@ -79,6 +81,7 @@ export class PlanPlayedComponent implements OnInit, OnDestroy {
   private translocoService = inject(TranslocoService);
   private analyticsService = inject(AnalyticsService);
   private trainingReminderService = inject(TrainingReminderService);
+  private appReviewService = inject(AppReviewService);
 
   /**
    * Menú minimalista de rutinas: animalito + duración (minutos).
@@ -112,6 +115,10 @@ export class PlanPlayedComponent implements OnInit, OnDestroy {
   private hasHadPlan: boolean = false; // Flag para saber si alguna vez tuvimos un plan
   // Evita evaluar/mostrar el prompt del recordatorio más de una vez por visita
   private reminderPromptChecked: boolean = false;
+  // Igual para la invitación a calificar la app
+  private appReviewChecked = false;
+  // Cálculo del ELO total y del récord de la rutina recién terminada
+  private eloReady: Promise<void> = Promise.resolve();
   private destroy$ = new Subject<void>();
 
   constructor() {
@@ -177,7 +184,9 @@ export class PlanPlayedComponent implements OnInit, OnDestroy {
           if (plan.isFinished === true) {
             this.hasHadPlan = true;
             this.plan = plan;
-            this.getTotalElo();
+            // Se guarda la promesa (sin await, para no retrasar los tableros):
+            // los avisos posteriores necesitan el récord y el ELO ya calculados.
+            this.eloReady = this.getTotalElo();
 
             this.plan.blocks.forEach((block, blockIndex) => {
               // Inicialmente carga 4 tableros por bloque
@@ -192,8 +201,8 @@ export class PlanPlayedComponent implements OnInit, OnDestroy {
               await this.checkLikeStatus();
             }
 
-            // Momento oportuno (peak-end) para proponer el recordatorio
-            void this.maybeShowReminderPrompt();
+            // Momento oportuno (peak-end) para los avisos de fin de rutina
+            void this.runPostRoutinePrompts();
           }
           // Si el plan no está terminado, ignorarlo (es un plan nuevo que se está creando)
         } else if (!plan && !this.isLoadingPlan && !this.hasHadPlan) {
@@ -224,25 +233,36 @@ export class PlanPlayedComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Avisos que aprovechan el pico emocional del final de rutina. Como mucho
+   * uno por visita: si se propone el recordatorio, la invitación a calificar
+   * espera a otra rutina en vez de encadenar dos tarjetas seguidas.
+   */
+  private async runPostRoutinePrompts(): Promise<void> {
+    const reminderShown = await this.maybeShowReminderPrompt();
+    await this.maybeRequestAppReview(!reminderShown);
+  }
+
+  /**
    * Propone activar el recordatorio de entrenamiento en el momento emocional
    * correcto (acaba de completar una sesión): solo en nativo, una sola vez,
    * con al menos 2 sesiones registradas y con el permiso aún sin decidir.
+   * Devuelve si se va a mostrar el modal.
    */
-  private async maybeShowReminderPrompt(): Promise<void> {
+  private async maybeShowReminderPrompt(): Promise<boolean> {
     if (this.reminderPromptChecked || this.isFromHistory) {
-      return;
+      return false;
     }
     this.reminderPromptChecked = true;
 
     if (!Capacitor.isNativePlatform()) {
-      return;
+      return false;
     }
     const state = this.trainingReminderService.getState();
     if (state.enabled || state.contextPromptShownAt !== null) {
-      return;
+      return false;
     }
     if (this.trainingReminderService.getEventsCount() < 2) {
-      return;
+      return false;
     }
     // Solo se descarta si el permiso está denegado en firme (no podría llegar
     // la notificación). Si está 'granted' (p. ej. Android <= 12, que lo concede
@@ -252,11 +272,38 @@ export class PlanPlayedComponent implements OnInit, OnDestroy {
     const permission =
       await this.trainingReminderService.checkPermissionStatus();
     if (permission === 'denied') {
-      return;
+      return false;
     }
 
     // Pequeño retardo para no competir con la animación de resultados
     setTimeout(() => void this.showReminderPrompt(), 800);
+    return true;
+  }
+
+  /**
+   * Suma esta rutina a los contadores de la invitación a calificar la app y,
+   * si el usuario ya lleva suficiente uso y la rutina salió bien, deja que
+   * salga la tarjeta nativa de la tienda. Los planes abiertos desde el
+   * historial no cuentan: no son una rutina recién terminada.
+   */
+  private async maybeRequestAppReview(canPrompt: boolean): Promise<void> {
+    if (this.appReviewChecked || this.isFromHistory || !this.plan) {
+      return;
+    }
+    this.appReviewChecked = true;
+
+    // El récord y el ELO ganado se calculan aparte; hay que esperarlos.
+    await this.eloReady;
+
+    await this.appReviewService.onRoutineFinished(
+      this.plan.uid,
+      {
+        isNewRecord: this.isNewRecord,
+        accuracy: routineAccuracy(this.plan.blocks),
+        eloDelta: this.eloDelta,
+      },
+      canPrompt
+    );
   }
 
   private async showReminderPrompt(): Promise<void> {

--- a/apps/chessColate/src/app/pages/settings/settings.page.html
+++ b/apps/chessColate/src/app/pages/settings/settings.page.html
@@ -90,6 +90,26 @@
         </ul>
       </section>
 
+      <!-- Apoya la app: calificar en la tienda (siempre disponible, sin cuota) -->
+      <section class="mb-8">
+        <div class="flex items-center gap-2 mb-3 opacity-80">
+          <ion-icon name="star-outline" class="text-xl"></ion-icon>
+          <h2 class="text-lg font-bold">{{ 'SETTINGS.support' | transloco }}</h2>
+        </div>
+
+        <ul class="menu bg-base-200/40 border border-base-content/10 w-full rounded-box gap-1 p-2">
+          <li>
+            <a (click)="rateApp()" class="flex items-center justify-between py-3">
+              <div>
+                <div class="text-base">{{ 'APP_REVIEW.rateRowTitle' | transloco }} ⭐</div>
+                <div class="text-xs opacity-60">{{ 'APP_REVIEW.rateRowDesc' | transloco }}</div>
+              </div>
+              <ion-icon name="chevron-forward-outline" class="text-xl opacity-60"></ion-icon>
+            </a>
+          </li>
+        </ul>
+      </section>
+
       <!-- Apariencia (próximamente: estilo de piezas y color de tablero) -->
       <!--
         Estos ajustes se implementarán más adelante. El modelo Profile ya tiene

--- a/apps/chessColate/src/app/pages/settings/settings.page.ts
+++ b/apps/chessColate/src/app/pages/settings/settings.page.ts
@@ -15,6 +15,7 @@ import {
   notificationsOutline,
   chevronForwardOutline,
   serverOutline,
+  starOutline,
 } from 'ionicons/icons';
 import { Subscription } from 'rxjs';
 
@@ -23,6 +24,7 @@ import { ProfileService } from '@services/profile.service';
 import { LanguageService, SupportedLang } from '@services/language.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { PuzzleStorageService } from '@services/puzzle-storage.service';
+import { AppReviewService } from '@services/app-review.service';
 
 addIcons({
   languageOutline,
@@ -34,6 +36,7 @@ addIcons({
   notificationsOutline,
   chevronForwardOutline,
   serverOutline,
+  starOutline,
 });
 
 interface LanguageOption {
@@ -54,6 +57,7 @@ export class SettingsPage implements OnInit, OnDestroy {
   private router = inject(Router);
   private analyticsService = inject(AnalyticsService);
   private puzzleStorageService = inject(PuzzleStorageService);
+  private appReviewService = inject(AppReviewService);
 
   readonly isNativePlatform = Capacitor.isNativePlatform();
 
@@ -114,6 +118,14 @@ export class SettingsPage implements OnInit, OnDestroy {
 
   goToStorage(): void {
     this.router.navigate(['/settings/storage']);
+  }
+
+  /**
+   * Abre la ficha de la tienda para calificar. Es la vía manual: no pasa por
+   * la tarjeta nativa, así que no tiene cuota ni espera de 90 días.
+   */
+  rateApp(): void {
+    this.appReviewService.openStoreListing();
   }
 
   /**

--- a/apps/chessColate/src/app/services/analytics.service.ts
+++ b/apps/chessColate/src/app/services/analytics.service.ts
@@ -38,7 +38,9 @@ export type AnalyticsEventName =
   | 'puzzle_storage_opened'
   | 'puzzle_storage_file_deleted'
   | 'puzzle_storage_theme_deleted'
-  | 'puzzle_storage_cleared';
+  | 'puzzle_storage_cleared'
+  | 'app_review_requested'
+  | 'app_review_store_opened';
 
 /** Valores primitivos admitidos por GA4 como parámetros de evento. */
 export type AnalyticsParams = Record<string, string | number | boolean>;

--- a/apps/chessColate/src/app/services/app-review-storage.service.ts
+++ b/apps/chessColate/src/app/services/app-review-storage.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+
+import { AppReviewState, DEFAULT_APP_REVIEW_STATE } from './app-review.util';
+
+/**
+ * Persistencia local de la invitación a calificar la app: contadores de uso y
+ * fecha de la última petición. Todo en localStorage, como el resto del estado
+ * local de la app (ver TrainingReminderStorageService).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AppReviewStorageService {
+  private readonly STATE_KEY = 'chessColate_app_review_state';
+
+  getState(): AppReviewState {
+    try {
+      const json = localStorage.getItem(this.STATE_KEY);
+      if (!json) {
+        return { ...DEFAULT_APP_REVIEW_STATE };
+      }
+      // Merge con defaults para tolerar estados guardados por versiones previas
+      return { ...DEFAULT_APP_REVIEW_STATE, ...JSON.parse(json) };
+    } catch (error) {
+      console.error('Error al leer el estado de la reseña:', error);
+      return { ...DEFAULT_APP_REVIEW_STATE };
+    }
+  }
+
+  saveState(state: AppReviewState): void {
+    try {
+      localStorage.setItem(this.STATE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.error('Error al guardar el estado de la reseña:', error);
+    }
+  }
+}

--- a/apps/chessColate/src/app/services/app-review.service.ts
+++ b/apps/chessColate/src/app/services/app-review.service.ts
@@ -1,0 +1,118 @@
+import { inject, Injectable } from '@angular/core';
+import { Capacitor } from '@capacitor/core';
+import { InAppReview } from '@capacitor-community/in-app-review';
+
+import { AnalyticsService } from './analytics.service';
+import { AppReviewStorageService } from './app-review-storage.service';
+import {
+  registerRoutine,
+  resolveTrigger,
+  markRequested,
+  RoutineOutcome,
+} from './app-review.util';
+
+/** Identificador de la app en las tiendas. */
+const APP_ID = 'com.jheison.chesscolate';
+/** Ficha en la Play Store (esquema nativo y fallback web). */
+const PLAY_STORE_APP_URL = `market://details?id=${APP_ID}`;
+const PLAY_STORE_WEB_URL = `https://play.google.com/store/apps/details?id=${APP_ID}`;
+
+/** Margen para que el usuario respire el resultado antes de que salga la tarjeta. */
+const REQUEST_DELAY_MS = 800;
+
+/**
+ * Fachada única de la invitación a calificar la app.
+ *
+ * Los componentes nunca llaman al plugin directamente: solo avisan de que
+ * terminó una rutina y cómo fue, y aquí se decide si toca pedir la reseña.
+ *
+ * - Toda la lógica de "cuándo" es nuestra (ver `app-review.util`): el API de
+ *   Google no admite pre-prompts ni incentivos, y ni siquiera informa de si el
+ *   usuario acabó calificando.
+ * - Solo en nativo: en web el plugin no hace nada y llamarlo gastaría el
+ *   cooldown de 90 días para nada.
+ * - Defensiva de principio a fin: pedir una reseña jamás debe romper el final
+ *   de una rutina.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class AppReviewService {
+  private storage = inject(AppReviewStorageService);
+  private analytics = inject(AnalyticsService);
+
+  /**
+   * Se llama al terminar una rutina, con el resultado a la vista. Actualiza
+   * los contadores y, si toca, muestra la tarjeta nativa de la tienda.
+   *
+   * `canPrompt` en false solo suma al contador: sirve para cuando la pantalla
+   * de resultados ya está mostrando otro aviso (p. ej. el del recordatorio) y
+   * no conviene encadenar dos.
+   */
+  async onRoutineFinished(
+    planUid: string,
+    outcome: RoutineOutcome,
+    canPrompt = true
+  ): Promise<void> {
+    const now = new Date();
+    const previous = this.storage.getState();
+    const state = registerRoutine(previous, planUid, now);
+
+    if (state === previous) {
+      // Este plan ya se contó (p. ej. se volvió a la pantalla de resultados).
+      return;
+    }
+    this.storage.saveState(state);
+
+    if (!canPrompt || !Capacitor.isNativePlatform()) {
+      return;
+    }
+
+    const trigger = resolveTrigger(state, outcome, now);
+    if (!trigger) {
+      return;
+    }
+
+    await this.delay(REQUEST_DELAY_MS);
+
+    try {
+      await InAppReview.requestReview();
+    } catch (error) {
+      console.warn('[AppReview] requestReview falló:', error);
+    }
+
+    // Se marca aunque el sistema no llegue a mostrar la tarjeta: no hay forma
+    // de saberlo, y reintentar en la siguiente rutina sería insistir a ciegas.
+    this.storage.saveState(markRequested(state, now));
+
+    void this.analytics.logEvent('app_review_requested', {
+      trigger,
+      completed_routines: state.completedRoutines,
+    });
+  }
+
+  /**
+   * Botón "Califícanos" de Ajustes: abre la ficha de la tienda. No pasa por el
+   * API nativo, así que no tiene cuota ni cooldown.
+   */
+  openStoreListing(): void {
+    void this.analytics.logEvent('app_review_store_opened');
+
+    const isAndroid = Capacitor.getPlatform() === 'android';
+    const url =
+      Capacitor.isNativePlatform() && isAndroid
+        ? PLAY_STORE_APP_URL
+        : PLAY_STORE_WEB_URL;
+
+    try {
+      window.open(url, '_blank');
+    } catch (error) {
+      console.warn('[AppReview] No se pudo abrir la ficha de la tienda:', error);
+      window.open(PLAY_STORE_WEB_URL, '_blank');
+    }
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/apps/chessColate/src/app/services/app-review.util.spec.ts
+++ b/apps/chessColate/src/app/services/app-review.util.spec.ts
@@ -1,0 +1,176 @@
+import {
+  AppReviewState,
+  DEFAULT_APP_REVIEW_STATE,
+  RoutineOutcome,
+  daysBetween,
+  isBadRoutine,
+  isEligible,
+  markRequested,
+  registerRoutine,
+  resolveTrigger,
+  routineAccuracy,
+} from './app-review.util';
+
+/** Estado de ejemplo, con lo mínimo para razonar sobre el gate. */
+function stateWith(overrides: Partial<AppReviewState> = {}): AppReviewState {
+  return { ...DEFAULT_APP_REVIEW_STATE, ...overrides };
+}
+
+/** Rutina que salió bien y sin récord (el caso más común). */
+function outcomeWith(overrides: Partial<RoutineOutcome> = {}): RoutineOutcome {
+  return { isNewRecord: false, accuracy: 0.8, eloDelta: 5, ...overrides };
+}
+
+/** Fecha local a mediodía, para que el huso no mueva el día. */
+function at(isoDate: string): Date {
+  const [year, month, day] = isoDate.split('-').map(Number);
+  return new Date(year, month - 1, day, 12, 0, 0);
+}
+
+describe('daysBetween', () => {
+  it('cuenta días completos entre dos fechas locales', () => {
+    expect(daysBetween('2026-01-01', '2026-04-01')).toBe(90);
+    expect(daysBetween('2026-01-01', '2026-01-01')).toBe(0);
+  });
+});
+
+describe('registerRoutine', () => {
+  it('suma la rutina y estrena el día y la fecha de primer uso', () => {
+    const state = registerRoutine(stateWith(), 'plan-1', at('2026-03-01'));
+
+    expect(state.completedRoutines).toBe(1);
+    expect(state.distinctDaysUsed).toBe(1);
+    expect(state.firstUseDate).toBe('2026-03-01');
+  });
+
+  it('no cuenta dos veces el mismo plan', () => {
+    const first = registerRoutine(stateWith(), 'plan-1', at('2026-03-01'));
+    const second = registerRoutine(first, 'plan-1', at('2026-03-01'));
+
+    expect(second).toBe(first);
+  });
+
+  it('varias rutinas el mismo día suman una sola jornada', () => {
+    let state = registerRoutine(stateWith(), 'plan-1', at('2026-03-01'));
+    state = registerRoutine(state, 'plan-2', at('2026-03-01'));
+
+    expect(state.completedRoutines).toBe(2);
+    expect(state.distinctDaysUsed).toBe(1);
+  });
+
+  it('marca la elegibilidad en la rutina que completa el gate', () => {
+    let state = registerRoutine(stateWith(), 'plan-1', at('2026-03-01'));
+    state = registerRoutine(state, 'plan-2', at('2026-03-02'));
+    expect(state.eligibleSince).toBeNull();
+
+    state = registerRoutine(state, 'plan-3', at('2026-03-02'));
+
+    expect(state.eligibleSince).toBe('2026-03-02');
+    expect(state.routinesSinceEligible).toBe(1);
+  });
+});
+
+describe('isEligible', () => {
+  const eligible = stateWith({ completedRoutines: 3, distinctDaysUsed: 2 });
+
+  it('exige 3 rutinas y 2 días distintos', () => {
+    expect(isEligible(eligible, at('2026-03-02'))).toBe(true);
+    expect(
+      isEligible({ ...eligible, completedRoutines: 2 }, at('2026-03-02'))
+    ).toBe(false);
+    expect(
+      isEligible({ ...eligible, distinctDaysUsed: 1 }, at('2026-03-02'))
+    ).toBe(false);
+  });
+
+  it('bloquea durante los 90 días siguientes a la última petición', () => {
+    const asked = { ...eligible, lastReviewRequestDate: '2026-01-01' };
+
+    expect(isEligible(asked, at('2026-03-31'))).toBe(false);
+    expect(isEligible(asked, at('2026-04-01'))).toBe(true);
+  });
+});
+
+describe('resolveTrigger', () => {
+  const now = at('2026-03-02');
+  const eligible = stateWith({
+    completedRoutines: 3,
+    distinctDaysUsed: 2,
+    eligibleSince: '2026-03-02',
+    routinesSinceEligible: 1,
+  });
+
+  it('no dispara si el usuario aún no es elegible', () => {
+    expect(resolveTrigger(stateWith(), outcomeWith(), now)).toBeNull();
+  });
+
+  it('el récord personal manda por encima de todo', () => {
+    expect(
+      resolveTrigger(eligible, outcomeWith({ isNewRecord: true }), now)
+    ).toBe('new_record');
+  });
+
+  it('una rutina que salió bien también sirve', () => {
+    expect(resolveTrigger(eligible, outcomeWith({ accuracy: 0.75 }), now)).toBe(
+      'good_routine'
+    );
+  });
+
+  it('nunca dispara justo después de una mala rutina', () => {
+    const bad = outcomeWith({ accuracy: 0.3, eloDelta: -12 });
+
+    expect(resolveTrigger(eligible, bad, now)).toBeNull();
+    expect(
+      resolveTrigger({ ...eligible, routinesSinceEligible: 9 }, bad, now)
+    ).toBeNull();
+  });
+
+  it('espera un pico durante 2 rutinas y en la siguiente pide igual', () => {
+    const tepid = outcomeWith({ accuracy: 0.6, eloDelta: 0 });
+
+    expect(
+      resolveTrigger({ ...eligible, routinesSinceEligible: 2 }, tepid, now)
+    ).toBeNull();
+    expect(
+      resolveTrigger({ ...eligible, routinesSinceEligible: 3 }, tepid, now)
+    ).toBe('grace_window');
+  });
+});
+
+describe('markRequested', () => {
+  it('arranca la espera y reinicia la ventana de gracia', () => {
+    const state = markRequested(
+      stateWith({ routinesSinceEligible: 4, eligibleSince: '2026-03-02' }),
+      at('2026-03-05')
+    );
+
+    expect(state.lastReviewRequestDate).toBe('2026-03-05');
+    expect(state.routinesSinceEligible).toBe(0);
+    expect(state.eligibleSince).toBeNull();
+  });
+});
+
+describe('isBadRoutine', () => {
+  it('es mala si falló más de la mitad o si bajó el ELO', () => {
+    expect(isBadRoutine(outcomeWith({ accuracy: 0.4 }))).toBe(true);
+    expect(isBadRoutine(outcomeWith({ eloDelta: -1 }))).toBe(true);
+    expect(isBadRoutine(outcomeWith({ accuracy: 0.6, eloDelta: 0 }))).toBe(
+      false
+    );
+  });
+});
+
+describe('routineAccuracy', () => {
+  it('cuenta los resueltos sobre el total de todos los bloques', () => {
+    const blocks = [
+      { puzzlesPlayed: [{ resolved: true }, { resolved: false }] },
+      { puzzlesPlayed: [{ resolved: true }, { resolved: true }] },
+    ];
+
+    expect(routineAccuracy(blocks)).toBe(0.75);
+  });
+
+  it('sin puzzles jugados no hay aciertos', () => {
+    expect(routineAccuracy([{ puzzlesPlayed: [] }])).toBe(0);
+  });
+});

--- a/apps/chessColate/src/app/services/app-review.util.ts
+++ b/apps/chessColate/src/app/services/app-review.util.ts
@@ -1,0 +1,217 @@
+/**
+ * Lógica pura de la invitación a calificar la app (sin Angular ni plugins).
+ *
+ * Aquí vive todo lo testeable de la feature: los contadores de uso, el gate de
+ * elegibilidad y la decisión de si este final de rutina es el momento correcto
+ * para mostrar la tarjeta nativa de la tienda.
+ * Ver docs/implementado/CALIFICAR_APP_FLOW.md.
+ */
+
+// Mismo formato de fecha local que usa el recordatorio de entrenamiento; se
+// reutiliza para no tener dos maneras distintas de escribir "hoy" en el
+// localStorage.
+import { toLocalISODate } from './training-reminder.util';
+
+export { toLocalISODate };
+
+/** Estado local de la feature. Nunca sale del dispositivo. */
+export interface AppReviewState {
+  /** Rutinas terminadas desde que se instaló la app. */
+  completedRoutines: number;
+  /** Días distintos en los que se terminó al menos una rutina. */
+  distinctDaysUsed: number;
+  /** 'YYYY-MM-DD' local de la última rutina contada (para no contar el día dos veces). */
+  lastRoutineDate: string | null;
+  /** uid del último plan contado, para que volver a la pantalla no infle el contador. */
+  lastCountedPlanUid: string | null;
+  /** 'YYYY-MM-DD' local de la primera rutina registrada. */
+  firstUseDate: string | null;
+  /** 'YYYY-MM-DD' local de la última vez que se llamó a requestReview(). */
+  lastReviewRequestDate: string | null;
+  /** 'YYYY-MM-DD' local desde que cumple el gate de elegibilidad. */
+  eligibleSince: string | null;
+  /** Rutinas terminadas ya siendo elegible (la que le dio la elegibilidad cuenta como 1). */
+  routinesSinceEligible: number;
+}
+
+export const DEFAULT_APP_REVIEW_STATE: AppReviewState = {
+  completedRoutines: 0,
+  distinctDaysUsed: 0,
+  lastRoutineDate: null,
+  lastCountedPlanUid: null,
+  firstUseDate: null,
+  lastReviewRequestDate: null,
+  eligibleSince: null,
+  routinesSinceEligible: 0,
+};
+
+/** Rutinas terminadas mínimas para considerar que hay opinión formada. */
+export const MIN_COMPLETED_ROUTINES = 3;
+/** Días distintos de uso mínimos: descarta a quien instaló hace un rato. */
+export const MIN_DISTINCT_DAYS = 2;
+/** Días de espera antes de volver a pedirla (por encima de la cuota del sistema). */
+export const REVIEW_COOLDOWN_DAYS = 90;
+/**
+ * Rutinas que se dejan pasar esperando un pico emocional. Si el usuario ya es
+ * elegible y pasan estas rutinas sin ningún "momento de victoria", se pide en
+ * la siguiente (siempre que no haya ido mal).
+ */
+export const GRACE_WINDOW_ROUTINES = 2;
+/** Aciertos (0–1) a partir de los cuales la rutina cuenta como buena. */
+export const GOOD_ACCURACY = 0.7;
+/** Aciertos por debajo de los cuales la rutina cuenta como mala. */
+export const BAD_ACCURACY = 0.5;
+
+/** Qué acabó disparando la petición (se reporta a analítica). */
+export type AppReviewTrigger = 'new_record' | 'good_routine' | 'grace_window';
+
+/** Cómo le fue al usuario en la rutina que acaba de terminar. */
+export interface RoutineOutcome {
+  /** Batió su máximo histórico de ELO en este tipo de rutina. */
+  isNewRecord: boolean;
+  /** Proporción de puzzles resueltos (0–1). */
+  accuracy: number;
+  /** Puntos de ELO ganados (+) o perdidos (−); null en planes antiguos. */
+  eloDelta: number | null;
+}
+
+/** Días completos entre dos fechas 'YYYY-MM-DD' locales. */
+export function daysBetween(fromISODate: string, toISODate: string): number {
+  const [fromYear, fromMonth, fromDay] = fromISODate.split('-').map(Number);
+  const [toYear, toMonth, toDay] = toISODate.split('-').map(Number);
+  const from = Date.UTC(fromYear, fromMonth - 1, fromDay);
+  const to = Date.UTC(toYear, toMonth - 1, toDay);
+  return Math.floor((to - from) / 86400000);
+}
+
+/**
+ * Actualiza los contadores tras terminar una rutina. Devuelve el estado sin
+ * tocar el original; el mismo plan no se cuenta dos veces (volver a la
+ * pantalla de resultados no debe inflar nada).
+ */
+export function registerRoutine(
+  state: AppReviewState,
+  planUid: string,
+  now: Date
+): AppReviewState {
+  if (state.lastCountedPlanUid === planUid) {
+    return state;
+  }
+
+  const today = toLocalISODate(now);
+  const isNewDay = state.lastRoutineDate !== today;
+
+  const next: AppReviewState = {
+    ...state,
+    completedRoutines: state.completedRoutines + 1,
+    distinctDaysUsed: state.distinctDaysUsed + (isNewDay ? 1 : 0),
+    lastRoutineDate: today,
+    lastCountedPlanUid: planUid,
+    firstUseDate: state.firstUseDate ?? today,
+  };
+
+  // La ventana de gracia solo empieza a correr cuando ya se cumple el gate.
+  if (next.eligibleSince !== null) {
+    next.routinesSinceEligible = state.routinesSinceEligible + 1;
+  } else if (meetsUsageGate(next)) {
+    next.eligibleSince = today;
+    next.routinesSinceEligible = 1;
+  }
+
+  return next;
+}
+
+/** Uso suficiente como para tener opinión formada (sin mirar el cooldown). */
+function meetsUsageGate(state: AppReviewState): boolean {
+  return (
+    state.completedRoutines >= MIN_COMPLETED_ROUTINES &&
+    state.distinctDaysUsed >= MIN_DISTINCT_DAYS
+  );
+}
+
+/** ¿Se le puede pedir la reseña a este usuario hoy? (uso suficiente + sin cooldown activo) */
+export function isEligible(state: AppReviewState, now: Date): boolean {
+  if (!meetsUsageGate(state)) {
+    return false;
+  }
+  if (state.lastReviewRequestDate === null) {
+    return true;
+  }
+  return (
+    daysBetween(state.lastReviewRequestDate, toLocalISODate(now)) >=
+    REVIEW_COOLDOWN_DAYS
+  );
+}
+
+/** La rutina fue claramente mal: nunca se pide la reseña justo después. */
+export function isBadRoutine(outcome: RoutineOutcome): boolean {
+  return (
+    outcome.accuracy < BAD_ACCURACY ||
+    (outcome.eloDelta !== null && outcome.eloDelta < 0)
+  );
+}
+
+/** Pico emocional: récord personal, o una rutina que salió bien. */
+function isWinningMoment(outcome: RoutineOutcome): boolean {
+  return (
+    outcome.isNewRecord ||
+    outcome.accuracy >= GOOD_ACCURACY ||
+    (outcome.eloDelta !== null && outcome.eloDelta > 0)
+  );
+}
+
+/** Ya se dejaron pasar suficientes rutinas esperando un pico que no llegó. */
+function graceWindowExpired(state: AppReviewState): boolean {
+  return state.routinesSinceEligible > GRACE_WINDOW_ROUTINES;
+}
+
+/**
+ * Decide si este final de rutina es el momento de pedir la reseña y con qué
+ * motivo. `null` = todavía no. Espera el estado **ya actualizado** con la
+ * rutina recién terminada (`registerRoutine`).
+ */
+export function resolveTrigger(
+  state: AppReviewState,
+  outcome: RoutineOutcome,
+  now: Date
+): AppReviewTrigger | null {
+  if (!isEligible(state, now)) {
+    return null;
+  }
+  if (outcome.isNewRecord) {
+    return 'new_record';
+  }
+  if (isBadRoutine(outcome)) {
+    // Ni siquiera por ventana de gracia: pedir reseña tras un mal rato es la
+    // mejor forma de ganarse una estrella.
+    return null;
+  }
+  if (isWinningMoment(outcome)) {
+    return 'good_routine';
+  }
+  return graceWindowExpired(state) ? 'grace_window' : null;
+}
+
+/** Marca que se pidió hoy: arranca el cooldown y reinicia la ventana de gracia. */
+export function markRequested(
+  state: AppReviewState,
+  now: Date
+): AppReviewState {
+  return {
+    ...state,
+    lastReviewRequestDate: toLocalISODate(now),
+    eligibleSince: null,
+    routinesSinceEligible: 0,
+  };
+}
+
+/** Proporción de puzzles resueltos (0–1) de una rutina. 0 si no se jugó ninguno. */
+export function routineAccuracy(
+  blocks: ReadonlyArray<{ puzzlesPlayed: ReadonlyArray<{ resolved: boolean }> }>
+): number {
+  const played = blocks.flatMap((block) => block.puzzlesPlayed);
+  if (played.length === 0) {
+    return 0;
+  }
+  return played.filter((puzzle) => puzzle.resolved).length / played.length;
+}

--- a/apps/chessColate/src/assets/i18n/en.json
+++ b/apps/chessColate/src/assets/i18n/en.json
@@ -527,7 +527,12 @@
     "language": "Language",
     "appearance": "Appearance",
     "notifications": "Notifications",
-    "storage": "Storage"
+    "storage": "Storage",
+    "support": "Support the app"
+  },
+  "APP_REVIEW": {
+    "rateRowTitle": "Rate us",
+    "rateRowDesc": "Leave a review on the store: it helps more people find ChessColate"
   },
   "STORAGE": {
     "pageTitle": "Downloaded puzzles",

--- a/apps/chessColate/src/assets/i18n/es.json
+++ b/apps/chessColate/src/assets/i18n/es.json
@@ -527,7 +527,12 @@
     "language": "Idioma",
     "appearance": "Apariencia",
     "notifications": "Notificaciones",
-    "storage": "Almacenamiento"
+    "storage": "Almacenamiento",
+    "support": "Apoya la app"
+  },
+  "APP_REVIEW": {
+    "rateRowTitle": "Califícanos",
+    "rateRowDesc": "Deja tu opinión en la tienda: ayuda a que más gente encuentre ChessColate"
   },
   "STORAGE": {
     "pageTitle": "Puzzles descargados",

--- a/docs/PENDIENTES.md
+++ b/docs/PENDIENTES.md
@@ -91,3 +91,24 @@ Orden acordado (ver docs de diseño en [features/](./features/)):
 4. **Chess Runner** — [features/CHESS_RUNNER.md](./features/CHESS_RUNNER.md). Requiere assets pixel-art + cerrar decisiones abiertas del doc.
 5. **Puzzle Geo Hunt** — [features/PUZZLE_GEO_HUNT.md](./features/PUZZLE_GEO_HUNT.md).
 6. **Cuadros de Conquista** — [features/CUADROS_DE_CONQUISTA.md](./features/CUADROS_DE_CONQUISTA.md). El más complejo; necesita un *design spike* que cierre poderes/economía/matchmaking antes de codificar.
+
+> El orden vivo está en [features/README.md](./features/README.md), que es el que se
+> mantiene al día conforme salen features.
+
+---
+
+## 4. Calificar la app (In-App Review) — verificación 🔴 (prioridad media)
+
+Implementado y documentado en [implementado/CALIFICAR_APP_FLOW.md](./implementado/CALIFICAR_APP_FLOW.md).
+Lo que no se puede cerrar desde el entorno de desarrollo:
+
+- **Probar la tarjeta nativa en un canal de pruebas de Play Store** 🔴 — en `debug`
+  la llamada no falla pero no muestra nada, que es el comportamiento esperado. Para
+  verla de verdad hace falta la app instalada desde Play (internal testing sirve).
+- **Comprobar que "Califícanos" abre la ficha** 🔴 — se usa `market://details?id=…`
+  en Android nativo y la URL web en el resto; conviene confirmarlo en dispositivo.
+- **iOS** 🔴 — el plugin soporta `SKStoreReviewController` y la lógica es la misma,
+  pero falta `npx cap sync ios`, validarlo en dispositivo y apuntar la fila de
+  Ajustes a la App Store en vez de a Play.
+- **Mirar la distribución de `trigger`** en GA4 tras unas semanas: si casi todo
+  entra por `grace_window`, los umbrales de "buena rutina" están demasiado altos.

--- a/docs/features/CALIFICAR_APP.md
+++ b/docs/features/CALIFICAR_APP.md
@@ -229,5 +229,3 @@ No hay toggle: el flujo autom√°tico es silencioso y de baja frecuencia por dise√
 - Hook en la pantalla de resultados de rutina ([`plan-played.component.ts`](../../apps/chessColate/src/app/pages/puzzles/containers/plan-played/plan-played.component.ts)) para llamar a `AppReviewService.maybeRequestReview(...)`.
 - `AnalyticsService` existente para los eventos.
 - App publicada en Play Store (o track de testing) para poder ver la tarjeta nativa en dispositivo.
-</content>
-</invoke>

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -14,63 +14,61 @@ El orden busca cuatro cosas, en este equilibrio: **(1)** despachar primero lo de
 | ✅ | — | [Recordatorios de Entrenamiento](../implementado/RECORDATORIOS_ENTRENAMIENTO_FLOW.md) | Alto (retención) | Medio | — |
 | ✅ | — | [Racha de Puzzles](../implementado/RACHA_STREAK_FLOW.md) | Alto (retención) | Medio | `board-puzzle` |
 | ✅ | — | [Gestión de Descargas de Puzzles](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md) | Medio (confianza/espacio) | Bajo-Medio | Caché de `puzzles-provider` (ya existe) |
-| ⬜ | 1 | [Calificar la App (In-App Review)](./CALIFICAR_APP.md) | Alto (negocio) | Bajo | Play Core (plugin nativo) |
-| ⬜ | 2 | [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md) | Medio | Medio | — (crea el util de PGN compartido) |
-| ⬜ | 3 | [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md) | Alto | Medio | #2 (parseo PGN) |
-| ⬜ | 4 | [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md) | Alto | Medio | #3 (set congelado) |
-| ⬜ | 5 | [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md) | Alto (estudio) | Alto | #2 (parseo PGN + navegación) |
-| ⬜ | 6 | [Puzzle Feed](./PUZZLE_FEED.md) | Alto (engagement) | Medio-Alto | — |
-| ⬜ | 7 | [Chess Runner](./CHESS_RUNNER.md) | Medio | Medio | — |
-| ⬜ | 8 | [Game Analytics](./GAME_ANALYTICS.md) | Alto | Alto | APIs externas (chess.com/lichess) |
-| ⬜ | 9 | [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md) | Alto | Alto (Nivel 1) / Muy Alto (Nivel 2) | #8 (ingesta de partidas) + `stockfish-wasm` |
-| ⬜ | 10 | [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md) | Alto | Muy Alto | Backend + matchmaking |
-| ⬜ | 11 | [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md) | Alto (competitivo/viral) | Alto | RTDB + matchmaking (sin backend propio) |
-| ⬜ | 12 | [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md) | Medio (nicho) | Muy Alto | GPS + AR + permisos |
+| ✅ | — | [Calificar la App (In-App Review)](../implementado/CALIFICAR_APP_FLOW.md) | Alto (negocio) | Bajo | `@capacitor-community/in-app-review` |
+| ⬜ | 1 | [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md) | Medio | Medio | — (crea el util de PGN compartido) |
+| ⬜ | 2 | [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md) | Alto | Medio | #1 (parseo PGN) |
+| ⬜ | 3 | [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md) | Alto | Medio | #2 (set congelado) |
+| ⬜ | 4 | [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md) | Alto (estudio) | Alto | #1 (parseo PGN + navegación) |
+| ⬜ | 5 | [Puzzle Feed](./PUZZLE_FEED.md) | Alto (engagement) | Medio-Alto | — |
+| ⬜ | 6 | [Chess Runner](./CHESS_RUNNER.md) | Medio | Medio | — |
+| ⬜ | 7 | [Game Analytics](./GAME_ANALYTICS.md) | Alto | Alto | APIs externas (chess.com/lichess) |
+| ⬜ | 8 | [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md) | Alto | Alto (Nivel 1) / Muy Alto (Nivel 2) | #7 (ingesta de partidas) + `stockfish-wasm` |
+| ⬜ | 9 | [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md) | Alto | Muy Alto | Backend + matchmaking |
+| ⬜ | 10 | [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md) | Alto (competitivo/viral) | Alto | RTDB + matchmaking (sin backend propio) |
+| ⬜ | 11 | [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md) | Medio (nicho) | Muy Alto | GPS + AR + permisos |
 
 > ✅ = ya implementado (detalle en [Ya implementado](#ya-implementado)) · ⬜ = pendiente.
 > Las filas con ✅ no llevan número porque ya salieron del orden de trabajo: eran las
 > dos primeras del plan original (**Notificaciones de Entrenamiento** y **Racha de
-> Puzzles**) más la base de observabilidad y la **Gestión de Descargas de Puzzles**.
+> Puzzles**), la base de observabilidad, la **Gestión de Descargas de Puzzles** y
+> **Calificar la App**.
 > Los pendientes se renumeran cuando una feature sale de la lista.
 
 ---
 
 ## Por qué este orden
 
-### 1 · [Calificar la App (In-App Review)](./CALIFICAR_APP.md)
-**Lo más barato con más retorno directo.** Es un servicio pequeño más un plugin nativo: no toca tablero, ni ELO, ni datos de entrenamiento. A cambio mueve la aguja donde más se nota — el rating y el volumen de reseñas de la ficha de Play Store, que es lo que decide si quien te encuentra se instala la app. Además **se apoya en cosas que ya existen**: el récord personal de la Racha y el fin de rutina son justo los picos emocionales donde conviene pedir la reseña.
-
-### 2 · [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md)
+### 1 · [Reproductor / TV de Partidas](./REPRODUCTOR_PARTIDAS.md)
 **Cimiento técnico de las tres siguientes.** Introduce el **util de parseo de PGN con `chess.js`** y **generaliza el motor de reproducción** de jugadas (a partir de [`board-puzzle-solution`](../../libs/board/src/lib/board-puzzle-solution/board-puzzle-solution.component.ts)). Es relativamente autocontenido (no toca ELO ni scoring) y deja listo un componente reutilizable.
 
-### 3 · [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md)
-**Reutiliza el parseo PGN de #2** y estrena el patrón de **"set de puzzles congelado y persistido"** (en vez de re-pedirlo al catálogo). Alto valor para entrenadores y estudio dirigido.
+### 2 · [Rutina con BD de Puzzles Personalizada (PGN)](./RUTINA_PGN_PERSONALIZADA.md)
+**Reutiliza el parseo PGN de #1** y estrena el patrón de **"set de puzzles congelado y persistido"** (en vez de re-pedirlo al catálogo). Alto valor para entrenadores y estudio dirigido.
 
-### 4 · [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md)
-**Reutiliza el "set congelado" de #3** y le añade **vueltas + timing decreciente + comparación entre pasadas**. Al llegar después de #3, gran parte de la persistencia y del juego por set ya está resuelta.
+### 3 · [Método del Pájaro Carpintero](./METODO_PAJARO_CARPINTERO.md)
+**Reutiliza el "set congelado" de #2** y le añade **vueltas + timing decreciente + comparación entre pasadas**. Al llegar después de #2, gran parte de la persistencia y del juego por set ya está resuelta.
 
-### 5 · [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md)
-**La versión activa de #2**: donde el reproductor deja mirar la partida, el analizador deja intervenirla — ramificar en variantes, comentar posiciones y dibujar encima del tablero (varias "láminas" por posición, alternables). Comparte con #2 el parseo PGN y la navegación, así que llega después; va tras el bloque de estudio (#3–#4) porque es **claramente el más caro de los cuatro**: árbol de variantes, persistencia propia y motor de dibujo sobre `canvas`.
+### 4 · [Analizador de Partidas (capas de dibujo)](./ANALIZADOR_PARTIDAS.md)
+**La versión activa de #1**: donde el reproductor deja mirar la partida, el analizador deja intervenirla — ramificar en variantes, comentar posiciones y dibujar encima del tablero (varias "láminas" por posición, alternables). Comparte con #1 el parseo PGN y la navegación, así que llega después; va tras el bloque de estudio (#2–#3) porque es **claramente el más caro de los cuatro**: árbol de variantes, persistencia propia y motor de dibujo sobre `canvas`.
 
-### 6 · [Puzzle Feed](./PUZZLE_FEED.md)
-**Motor de engagement** estilo TikTok/Reels sobre puzzles. Reutiliza [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) y el catálogo; el algoritmo de recomendación puede empezar **local** (ELO + temas + historial) sin backend. Alto potencial de uso, independiente de #2–#5.
+### 5 · [Puzzle Feed](./PUZZLE_FEED.md)
+**Motor de engagement** estilo TikTok/Reels sobre puzzles. Reutiliza [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) y el catálogo; el algoritmo de recomendación puede empezar **local** (ELO + temas + historial) sin backend. Alto potencial de uso, independiente de #1–#4.
 
-### 7 · [Chess Runner](./CHESS_RUNNER.md)
+### 6 · [Chess Runner](./CHESS_RUNNER.md)
 **Capa de gamificación** (mini-juego previo al puzzle). Autocontenido, sin dependencias de datos externas; encaja cuando ya hay volumen de puzzles jugándose. Esfuerzo medio (animación/gameplay).
 
-### 8 · [Game Analytics](./GAME_ANALYTICS.md)
+### 7 · [Game Analytics](./GAME_ANALYTICS.md)
 **Nuevas libs** (`chess-com-provider`, `lichess-provider`, `game-reporter`) y **APIs externas**. Alto valor pero mayor superficie y dependencia de terceros; es bastante independiente, así que puede solaparse en paralelo con las anteriores si hay capacidad.
 
-### 9 · [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md)
-**Consume directamente la ingesta de #8**: los providers de chess.com/lichess, el caché de partidas y el modelo `ChessGame`. A partir de ahí construye un **perfil de estilo** y un rival jugable que aproxima tu fuerza y tus manías. El **Nivel 1** (perfil estadístico + Stockfish sesgado con [`stockfish-wasm`](../../libs/stockfish-wasm/src/lib/)) es **on-device, sin backend** — de ahí que llegue justo tras #8. El **Nivel 2** (clon neuronal tipo Maia fine-tuneado) es I+D con GPU/backend y **no bloquea** el lanzamiento.
+### 8 · [Sparring Personalizado (IA con tu estilo)](./SPARRING_PERSONALIZADO.md)
+**Consume directamente la ingesta de #7**: los providers de chess.com/lichess, el caché de partidas y el modelo `ChessGame`. A partir de ahí construye un **perfil de estilo** y un rival jugable que aproxima tu fuerza y tus manías. El **Nivel 1** (perfil estadístico + Stockfish sesgado con [`stockfish-wasm`](../../libs/stockfish-wasm/src/lib/)) es **on-device, sin backend** — de ahí que llegue justo tras #7. El **Nivel 2** (clon neuronal tipo Maia fine-tuneado) es I+D con GPU/backend y **no bloquea** el lanzamiento.
 
-### 10 · [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md)
-**PvP asíncrono** con matchmaking, economía de poderes y estado compartido → **requiere backend**. Complejidad alta; conviene atacarlo cuando la base de usuarios (que la Racha y #6 ayudan a crecer) lo justifique.
+### 9 · [Cuadros de Conquista](./CUADROS_DE_CONQUISTA.md)
+**PvP asíncrono** con matchmaking, economía de poderes y estado compartido → **requiere backend**. Complejidad alta; conviene atacarlo cuando la base de usuarios (que la Racha y #5 ayudan a crecer) lo justifique.
 
-### 11 · [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md)
-**PvP en tiempo real** estilo [Puzzle Racer de Lichess](https://lichess.org/racer): varios jugadores compiten sobre la **misma secuencia de puzzles** contra el reloj. A diferencia de #10, está diseñado para correr **sin backend propio**: Firebase solo transporta enteros diminutos por un canal efímero de **Realtime Database** y el contenido de los puzzles sale del CDN + caché que ya existe — el objetivo explícito es que **casi no consuma recursos de Firebase** (~10 000 carreras por dólar de ancho de banda). Estrena el bloque compartido de **RTDB + matchmaking client-side** que #10 puede reutilizar. Alto valor competitivo/viral; llega en el clúster PvP porque el matchmaking y la sincronización son la parte más delicada.
+### 10 · [Puzzle Racer (Multijugador)](./PUZZLE_RACER.md)
+**PvP en tiempo real** estilo [Puzzle Racer de Lichess](https://lichess.org/racer): varios jugadores compiten sobre la **misma secuencia de puzzles** contra el reloj. A diferencia de #9, está diseñado para correr **sin backend propio**: Firebase solo transporta enteros diminutos por un canal efímero de **Realtime Database** y el contenido de los puzzles sale del CDN + caché que ya existe — el objetivo explícito es que **casi no consuma recursos de Firebase** (~10 000 carreras por dólar de ancho de banda). Estrena el bloque compartido de **RTDB + matchmaking client-side** que #9 puede reutilizar. Alto valor competitivo/viral; llega en el clúster PvP porque el matchmaking y la sincronización son la parte más delicada.
 
-### 12 · [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md)
+### 11 · [Puzzle Geo Hunt](./PUZZLE_GEO_HUNT.md)
 **GPS + AR + permisos de cámara/ubicación.** El más caro en hardware/plataforma y el más de nicho. Último, como apuesta diferenciadora una vez consolidado el núcleo.
 
 ---
@@ -79,12 +77,12 @@ El orden busca cuatro cosas, en este equilibrio: **(1)** despachar primero lo de
 
 Conviene tratarlos como piezas transversales, no re-implementarlas por feature:
 
-- **Util de parseo PGN** (`chess.js`) → lo estrena #2 y lo reutilizan #3, #4 y #5. Extraer a [`libs/common-utils`](../../libs/common-utils).
-- **Set de puzzles congelado y persistido por id** → patrón común de #3 y #4 (y posible fuente de sets en #4). Evita el _strip_ actual de `puzzles` al guardar planes.
-- **Motor de reproducción de jugadas** (tablero + secuencia de FEN/SAN + controles) → de #2, reutilizable donde se "reproduzca" una línea; #5 lo extiende con el árbol de variantes.
-- **Board de puzzles** [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) → ya existe; lo consumen la Racha, #3, #4, #6, #7, #11 y #12.
+- **Util de parseo PGN** (`chess.js`) → lo estrena #1 y lo reutilizan #2, #3 y #4. Extraer a [`libs/common-utils`](../../libs/common-utils).
+- **Set de puzzles congelado y persistido por id** → patrón común de #2 y #3 (y posible fuente de sets en #3). Evita el _strip_ actual de `puzzles` al guardar planes.
+- **Motor de reproducción de jugadas** (tablero + secuencia de FEN/SAN + controles) → de #1, reutilizable donde se "reproduzca" una línea; #4 lo extiende con el árbol de variantes.
+- **Board de puzzles** [`board-puzzle`](../../libs/board/src/lib/board-puzzle/board-puzzle.component.ts) → ya existe; lo consumen la Racha, #2, #3, #5, #6, #10 y #11.
 - **Metadata del caché de puzzles** (tema + rango de ELO + tamaño por archivo descargado) → **ya existe**: la estrenó la [Gestión de Descargas](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md) y deja medible cuánto espacio ocupa la app.
-- **RTDB + matchmaking client-side** (canal efímero de tiempo real, transacciones de lobby, `onDisconnect`) → lo estrena #11 y lo puede reutilizar #10 (Cuadros de Conquista) para su capa PvP. RTDB no está cableada hoy (solo Firestore).
+- **RTDB + matchmaking client-side** (canal efímero de tiempo real, transacciones de lobby, `onDisconnect`) → lo estrena #10 y lo puede reutilizar #9 (Cuadros de Conquista) para su capa PvP. RTDB no está cableada hoy (solo Firestore).
 - **AnalyticsService** [(catálogo)](../implementado/OBSERVABILITY_TRACKING.md) → todas instrumentan sobre la base ya implementada.
 
 ---
@@ -92,9 +90,9 @@ Conviene tratarlos como piezas transversales, no re-implementarlas por feature:
 ## Leyenda
 
 - **Estado**: ✅ implementado · ⬜ pendiente.
-- **Valor**: impacto esperado en retención/engagement/diferenciación (o en negocio, en el caso de #1).
+- **Valor**: impacto esperado en retención/engagement/diferenciación (o en negocio).
 - **Esfuerzo**: tamaño relativo de implementación (incl. infra y plataforma).
-- El orden es una **recomendación**, no un contrato: #8 (Game Analytics) es lo bastante independiente como para paralelizarse; #6 (Puzzle Feed) puede adelantarse si la prioridad es crecimiento antes que las herramientas de estudio (#2–#5).
+- El orden es una **recomendación**, no un contrato: #7 (Game Analytics) es lo bastante independiente como para paralelizarse; #5 (Puzzle Feed) puede adelantarse si la prioridad es crecimiento antes que las herramientas de estudio (#1–#4).
 
 ---
 
@@ -105,3 +103,4 @@ Conviene tratarlos como piezas transversales, no re-implementarlas por feature:
 - [Racha de Puzzles](../implementado/RACHA_STREAK_FLOW.md) — modo de muerte súbita con dificultad creciente y récord personal. Idea original en [`RACHA_STREAK.md`](./RACHA_STREAK.md).
 - [Pool de Puzzles del Entrenamiento Continuo](../implementado/INFINITY_PUZZLE_POOL_FLOW.md) — 50 puzzles pre-cargados en IndexedDB que comparten la tarjeta del home y la sesión de entrenamiento continuo, para no repetir peticiones al CDN.
 - [Gestión de Descargas de Puzzles](../implementado/GESTION_DESCARGAS_PUZZLES_FLOW.md) — pantalla de Almacenamiento que lista los archivos descargados por tema y rango de ELO, con su tamaño, y permite borrarlos. Idea original en [`GESTION_DESCARGAS_PUZZLES.md`](./GESTION_DESCARGAS_PUZZLES.md).
+- [Calificar la App (In-App Review)](../implementado/CALIFICAR_APP_FLOW.md) — invitación silenciosa a calificar en la Play Store, solo tras una rutina que salió bien y como mucho cada 90 días, más un acceso manual en Ajustes. Idea original en [`CALIFICAR_APP.md`](./CALIFICAR_APP.md).

--- a/docs/implementado/CALIFICAR_APP_FLOW.md
+++ b/docs/implementado/CALIFICAR_APP_FLOW.md
@@ -1,0 +1,198 @@
+# Flujo de la invitación a calificar la app
+
+La app pide la reseña **sola, una vez cada mucho, y solo cuando al usuario le
+acaba de ir bien**. Para eso usa la tarjeta nativa de la Play Store (In-App
+Review), que aparece encima de la pantalla de resultados sin sacar a nadie de
+la app. Además, en Ajustes hay un acceso directo a la ficha de la tienda para
+quien quiera calificar por iniciativa propia.
+
+> Este documento describe cómo funciona lo implementado. La idea original
+> (planificación) está en
+> [`../features/CALIFICAR_APP.md`](../features/CALIFICAR_APP.md).
+
+---
+
+## Qué ve el usuario
+
+**Nada, casi nunca.** Ese es el objetivo. Terminada una rutina, si se cumplen
+todas las condiciones, unos 800 ms después de ver el resultado aparece la
+tarjeta del sistema con las estrellas y el campo de comentario. Si no se
+cumplen, no pasa absolutamente nada.
+
+En **Ajustes** hay una sección nueva, *Apoya la app*, con una fila
+**"Califícanos ⭐"** que abre la ficha de la Play Store. Esta vía no tiene cuota
+ni espera: está siempre disponible.
+
+## Cuándo se pide
+
+Dos capas: primero *¿es este usuario candidato?* y luego *¿es este el instante?*
+
+### Capa 1 — el gate (deben cumplirse todas)
+
+| Condición | Valor |
+|---|---|
+| Rutinas terminadas | **≥ 3** |
+| Días distintos con rutina terminada | **≥ 2** |
+| Desde la última petición | **≥ 90 días** |
+
+Las tres se evalúan sobre contadores propios (ver *Dónde vive el dato*). Los 90
+días son **nuestros**, por encima de la cuota que el sistema aplica por su
+cuenta: sirven para no gastar intentos a ciegas.
+
+### Capa 2 — el instante
+
+Con el gate cumplido, se mira cómo fue la rutina que se acaba de terminar:
+
+| Situación | Resultado | `trigger` |
+|---|---|---|
+| Batió su récord de ELO | se pide | `new_record` |
+| Falló más de la mitad, o perdió ELO | **nunca** se pide | — |
+| Acertó ≥ 70 %, o ganó ELO | se pide | `good_routine` |
+| Rutina tibia (ni buena ni mala) | se espera | — |
+| Tercera rutina tibia seguida | se pide igual | `grace_window` |
+
+La **ventana de gracia** existe porque hay quien entrena tranquilo y nunca
+tiene un pico claro: si se esperara siempre a la victoria, a esa persona no se
+le pediría la reseña jamás. Aun así, la regla de "nunca tras un mal rato" está
+por encima de la ventana — pedir estrellas justo después de una rutina fallida
+es la mejor forma de ganarse una.
+
+Cuando se pide, se marca la fecha y **se reinicia la ventana de gracia**. Se
+marca aunque el sistema decida no mostrar la tarjeta: no hay forma de saber si
+la mostró, y reintentar en la siguiente rutina sería insistir a ciegas.
+
+### Un solo aviso por visita
+
+La pantalla de resultados ya tenía otro aviso en el mismo momento emocional: el
+modal que propone activar el recordatorio de entrenamiento. Encadenar los dos
+sería justo la clase de acoso que esta feature intenta evitar, así que se
+resuelven en orden y **solo se muestra uno**:
+
+```
+runPostRoutinePrompts()
+   │
+   ├─ ¿toca proponer el recordatorio?  ─ sí ─▶ modal del recordatorio
+   │                                            (la reseña solo suma al contador)
+   └─ no ─▶ ¿toca pedir la reseña?     ─ sí ─▶ tarjeta nativa de la tienda
+```
+
+La rutina **siempre se cuenta**, se muestre lo que se muestre; lo único que
+cambia es si además se puede pedir la reseña.
+
+## Dónde vive el dato
+
+Un único registro en `localStorage`, bajo la clave
+`chessColate_app_review_state`. Nunca sale del dispositivo y no hay backend.
+
+```ts
+interface AppReviewState {
+  completedRoutines: number;        // rutinas terminadas en total
+  distinctDaysUsed: number;         // días distintos con al menos una
+  lastRoutineDate: string | null;   // 'YYYY-MM-DD' de la última contada
+  lastCountedPlanUid: string | null;// para no contar dos veces el mismo plan
+  firstUseDate: string | null;
+  lastReviewRequestDate: string | null;  // arranca la espera de 90 días
+  eligibleSince: string | null;
+  routinesSinceEligible: number;    // ventana de gracia
+}
+```
+
+**No se guarda si el usuario calificó**: el API nativo no lo informa. Lo único
+que se sabe es que *se pidió*.
+
+`lastCountedPlanUid` cubre un detalle real de la pantalla: se puede volver a
+ella (desde el historial, o porque el observable del plan vuelve a emitir) y sin
+esa comprobación el contador se inflaría solo. Los planes abiertos desde el
+historial, además, no cuentan en absoluto — no son una rutina recién terminada.
+
+## Arquitectura
+
+```
+plan-played.component.ts     (sabe cómo fue la rutina)
+      │
+      ▼
+AppReviewService             (decide y llama al plugin)   ← fachada
+      │              │
+      ▼              ▼
+app-review.util   AppReviewStorageService
+(lógica pura)     (localStorage)
+      │
+      ▼
+@capacitor-community/in-app-review
+```
+
+Mismo principio de fachada que el `AnalyticsService`: **los componentes nunca
+llaman al plugin**. La pantalla solo informa de `{ isNewRecord, accuracy,
+eloDelta }` y el servicio decide.
+
+Toda la lógica de decisión vive en [`app-review.util.ts`](../../apps/chessColate/src/app/services/app-review.util.ts),
+sin Angular ni plugins, que es lo que la hace testeable: los 16 tests de
+`app-review.util.spec.ts` cubren el gate, la espera de 90 días, la ventana de
+gracia y la regla de la mala rutina sin necesidad de un dispositivo.
+
+### Por qué la lógica es nuestra
+
+El In-App Review API de Google es estricto y **no admite** pre-prompts
+("¿te gusta la app? sí/no"), incentivos, ni condicionar funciones a calificar.
+Tampoco informa del resultado ni garantiza que la tarjeta llegue a mostrarse.
+Por eso a Google solo se le pide `requestReview()`; el "cuándo" es todo nuestro.
+
+## Decisiones
+
+| Decisión | Cómo quedó | Por qué |
+|---|---|---|
+| **Umbral de rutinas** | 3 | Con 1 no hay opinión formada; con 5 se llega tarde. |
+| **Espera entre peticiones** | 90 días | Como mucho cuatro al año, por encima de la cuota del sistema. |
+| **Ventana de gracia** | 2 rutinas tibias, se pide en la siguiente | Que el usuario tranquilo también entre, sin renunciar a buscar el pico. |
+| **Puntos de disparo** | Solo el fin de rutina | Es donde ya se detecta el récord de ELO y donde vive el otro aviso, así que la exclusión mutua es trivial. Añadir Racha o Coordenadas multiplicaría los sitios a probar por poco a cambio. |
+| **Toggle para apagarlo** | No | El flujo es silencioso y de baja frecuencia por diseño; ofrecer un interruptor invita a buscarlo. |
+| **Reto 333** | Fuera | Termina en su propio modal y navega a home: no pasa por la pantalla de resultados. |
+| **Web/PWA** | Solo se cuentan las rutinas | El plugin no hace nada en web y llamarlo gastaría la espera de 90 días para nada. La fila de Ajustes sí funciona: abre la ficha web. |
+
+## Bordes conocidos
+
+- **En desarrollo la tarjeta no aparece.** El In-App Review solo funciona con la
+  app instalada desde Play Store o desde un canal de pruebas. En `debug` la
+  llamada no falla, simplemente no muestra nada — es lo esperado.
+- **Cuota del sistema**: aunque se cumplan todas las condiciones, Google puede
+  decidir no mostrarla. No hay forma de saberlo ni de forzarlo.
+- **iOS queda pendiente**: el plugin lo soporta (`SKStoreReviewController`) y la
+  lógica es la misma, pero no se ha validado en dispositivo ni se ha revisado el
+  copy de la tienda. La fila de Ajustes apunta hoy a la Play Store.
+- **Si se borran los datos de la app** se pierden los contadores y el usuario
+  vuelve a empezar el gate desde cero. Aceptable: no hay nada que valga la pena
+  sincronizar a Firestore por esto.
+
+## Analítica
+
+Dos eventos, catalogados en
+[OBSERVABILITY_REFERENCIA](./OBSERVABILITY_REFERENCIA.md#6-catálogo-de-eventos-as-built):
+
+| Evento | Params |
+|---|---|
+| `app_review_requested` | `trigger`, `completed_routines` |
+| `app_review_store_opened` | — |
+
+No se puede medir si alguien calificó; se miden **peticiones** y **aperturas
+manuales**. El impacto real se ve en el volumen y el rating de Play Console, y
+la distribución de `trigger` dice si la ventana de gracia está haciendo falta o
+si casi todo entra por `new_record`.
+
+## Archivos
+
+| Archivo | Rol |
+|---|---|
+| [`services/app-review.util.ts`](../../apps/chessColate/src/app/services/app-review.util.ts) | lógica pura: contadores, gate, disparador |
+| [`services/app-review.util.spec.ts`](../../apps/chessColate/src/app/services/app-review.util.spec.ts) | tests de la lógica |
+| [`services/app-review-storage.service.ts`](../../apps/chessColate/src/app/services/app-review-storage.service.ts) | `localStorage` |
+| [`services/app-review.service.ts`](../../apps/chessColate/src/app/services/app-review.service.ts) | fachada: plugin, ficha de la tienda, analítica |
+| [`plan-played.component.ts`](../../apps/chessColate/src/app/pages/puzzles/containers/plan-played/plan-played.component.ts) | enganche y exclusión con el aviso del recordatorio |
+| [`settings.page.html`](../../apps/chessColate/src/app/pages/settings/settings.page.html) | sección *Apoya la app* |
+| `assets/i18n/{es,en}.json` | claves `SETTINGS.support` y `APP_REVIEW.*` |
+| `apps/chessColate/android/` | registro del plugin (`npx cap sync android`) |
+
+## Fuera de alcance
+
+iOS, hitos de racha como disparador, y cualquier A/B testing del momento o de
+los umbrales. Los tres se deciden mejor **con los datos** que empiece a dar
+`app_review_requested`.

--- a/docs/implementado/OBSERVABILITY_REFERENCIA.md
+++ b/docs/implementado/OBSERVABILITY_REFERENCIA.md
@@ -90,6 +90,8 @@ legible). El resto son **acciones semánticas**. Nombres y params en `snake_case
 | `puzzle_storage_file_deleted` | borra un archivo | `theme` (tema o apertura), `elo_start` | `settings/storage/storage.page.ts` |
 | `puzzle_storage_theme_deleted` | borra un tema/apertura entero | `theme`, `files_count`, `size_mb` | `settings/storage/storage.page.ts` |
 | `puzzle_storage_cleared` | borra todo lo descargado | `files_count`, `size_mb` | `settings/storage/storage.page.ts` |
+| `app_review_requested` | se pide la tarjeta nativa de la tienda | `trigger` (`new_record`/`good_routine`/`grace_window`), `completed_routines` | `app-review.service.ts` |
+| `app_review_store_opened` | toca "Califícanos" en Ajustes | — | `app-review.service.ts` |
 
 \* `routine_uid`/`author_uid` solo en rutinas custom/públicas.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser-dynamic": "~20.3.0",
         "@angular/router": "~20.3.0",
         "@angular/service-worker": "^20.3.0",
+        "@capacitor-community/in-app-review": "^7.1.0",
         "@capacitor-firebase/analytics": "^7.5.0",
         "@capacitor-firebase/authentication": "^7.4.0",
         "@capacitor-firebase/crashlytics": "^7.5.0",
@@ -4185,6 +4186,15 @@
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@capacitor-community/in-app-review": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/in-app-review/-/in-app-review-7.1.0.tgz",
+      "integrity": "sha512-qB0Q+qvPxF03UWoryZubyMkOCRqJF5xEILjt+VC4768yyilyss4k6qDjT6x9x7T4T8o8kmGgbPBJgwf1fsLa1A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
     },
     "node_modules/@capacitor-firebase/analytics": {
       "version": "7.5.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@angular/platform-browser-dynamic": "~20.3.0",
     "@angular/router": "~20.3.0",
     "@angular/service-worker": "^20.3.0",
+    "@capacitor-community/in-app-review": "^7.1.0",
     "@capacitor-firebase/analytics": "^7.5.0",
     "@capacitor-firebase/authentication": "^7.4.0",
     "@capacitor-firebase/crashlytics": "^7.5.0",


### PR DESCRIPTION
Pide la reseña con la tarjeta nativa de la Play Store solo cuando el usuario lleva 3 rutinas en 2 días distintos, no se le pidió en los últimos 90 días y la rutina que acaba de terminar salió bien (récord de ELO, buena precisión o ELO ganado). Tras una mala rutina no se pide nunca. Si son 3 rutinas tibias seguidas se pide igual, para no dejar fuera a quien entrena tranquilo.

La pantalla de resultados ya mostraba el aviso del recordatorio en ese mismo instante: ahora se resuelven en orden y solo sale uno por visita (la rutina se cuenta igual).

En Ajustes se añade "Califícanos", que abre la ficha de la tienda sin pasar por el API nativo, así que no tiene cuota ni espera.

- Lógica pura y testeada en app-review.util.ts (16 tests)
- Contadores en localStorage; nada sale del dispositivo
- Fachada AppReviewService: los componentes no tocan el plugin
- Eventos app_review_requested / app_review_store_opened
- Plugin @capacitor-community/in-app-review v7 (la v8 exige Capacitor 8)
- Documentado en docs/implementado/CALIFICAR_APP_FLOW.md